### PR TITLE
Support browsing for sites

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -25,6 +25,8 @@ async function start(): Promise<void> {
 
   const mb = menubar({
     dir,
+    // If we're running develop we pass in a URL, otherwise use the one
+    // of the express server we just started
     index: process.env.GATSBY_DEVELOP_URL || `http://localhost:${port}`,
     browserWindow: {
       webPreferences: {
@@ -33,7 +35,7 @@ async function start(): Promise<void> {
       },
     },
   })
-
+  // This request comes from the renderer
   ipcMain.handle(`browse-for-site`, async () => {
     console.log(`Browsing for site`)
     const { canceled, filePaths } = await dialog.showOpenDialog({
@@ -44,7 +46,7 @@ async function start(): Promise<void> {
     }
 
     const path = filePaths[0]
-
+    // i.e. actually installed in node_modules
     if (await hasGatsbyInstalled(path)) {
       const packageJson = await loadPackageJson(path)
       return { packageJson, path }
@@ -52,6 +54,7 @@ async function start(): Promise<void> {
 
     try {
       const packageJson = await loadPackageJson(path)
+      // Has a dependency but it hasn't been installed
       if (hasGatsbyDependency(packageJson)) {
         return {
           packageJson,

--- a/app/main.ts
+++ b/app/main.ts
@@ -46,14 +46,12 @@ async function start(): Promise<void> {
     }
 
     const path = filePaths[0]
-    // i.e. actually installed in node_modules
-    if (await hasGatsbyInstalled(path)) {
-      const packageJson = await loadPackageJson(path)
-      return { packageJson, path }
-    }
-
     try {
       const packageJson = await loadPackageJson(path)
+      // i.e. actually installed in node_modules
+      if (await hasGatsbyInstalled(path)) {
+        return { packageJson, path }
+      }
       // Has a dependency but it hasn't been installed
       if (hasGatsbyDependency(packageJson)) {
         return {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -18,6 +18,6 @@ export async function loadPackageJson(root: string): Promise<PackageJson> {
 }
 
 export function hasGatsbyDependency(packageJson: PackageJson): boolean {
-  const { dependencies = {}, devDependencies = {} } = packageJson
-  return !!{ ...dependencies, ...devDependencies }.gatsby
+  const { dependencies, devDependencies } = packageJson
+  return !!(dependencies?.gatsby || devDependencies?.gatsby)
 }

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,0 +1,23 @@
+import { readJSON } from "fs-extra"
+import { PackageJson } from "gatsby"
+import path from "path"
+export async function hasGatsbyInstalled(root: string): Promise<boolean> {
+  try {
+    const packageJson = await readJSON(
+      path.join(root, `node_modules`, `gatsby`, `package.json`)
+    )
+    return packageJson?.name === `gatsby`
+  } catch (e) {
+    console.warn({ e })
+    return false
+  }
+}
+
+export async function loadPackageJson(root: string): Promise<PackageJson> {
+  return readJSON(path.join(root, `package.json`))
+}
+
+export function hasGatsbyDependency(packageJson: PackageJson): boolean {
+  const { dependencies = {}, devDependencies = {} } = packageJson
+  return !!{ ...dependencies, ...devDependencies }.gatsby
+}

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,5 @@
+import React from "react"
+import { RunnerProvider } from "./src/components/site-runners"
+export const wrapRootElement = ({ element }) => (
+  <RunnerProvider>{element}</RunnerProvider>
+)

--- a/src/components/site-browser.tsx
+++ b/src/components/site-browser.tsx
@@ -18,6 +18,8 @@ export function SiteBrowser({
 }: IProps): JSX.Element {
   const browse = useCallback(async () => {
     console.log(`browsing`)
+    // Sends a essage to the main process asking for a file dialog.
+    // It also verifies that it's a Gatsby site before returning it.
     const result: ISiteInfo | ISiteError | undefined = await ipcRenderer.invoke(
       `browse-for-site`,
       {}

--- a/src/components/site-browser.tsx
+++ b/src/components/site-browser.tsx
@@ -18,7 +18,7 @@ export function SiteBrowser({
 }: IProps): JSX.Element {
   const browse = useCallback(async () => {
     console.log(`browsing`)
-    // Sends a essage to the main process asking for a file dialog.
+    // Sends a message to the main process asking for a file dialog.
     // It also verifies that it's a Gatsby site before returning it.
     const result: ISiteInfo | ISiteError | undefined = await ipcRenderer.invoke(
       `browse-for-site`,

--- a/src/components/site-browser.tsx
+++ b/src/components/site-browser.tsx
@@ -1,15 +1,39 @@
 import React, { HTMLAttributes, useCallback } from "react"
 import { ipcRenderer } from "electron"
+import { ISiteInfo } from "../controllers/site"
+
 interface IProps extends HTMLAttributes<HTMLButtonElement> {
-  onSelect: () => void
+  onSelectSite: (siteInfo: ISiteInfo) => void
+  onSiteError: (message?: string) => void
 }
 
-export function SiteBrowser({ onSelect, ...props }: IProps): JSX.Element {
+interface ISiteError {
+  error: string
+}
+
+export function SiteBrowser({
+  onSelectSite,
+  onSiteError,
+  ...props
+}: IProps): JSX.Element {
   const browse = useCallback(async () => {
     console.log(`browsing`)
-    const result = await ipcRenderer.invoke(`browse-for-site`, {})
+    const result: ISiteInfo | ISiteError | undefined = await ipcRenderer.invoke(
+      `browse-for-site`,
+      {}
+    )
+    if (!result) {
+      return
+    }
+    if (`error` in result) {
+      onSiteError(result.error)
+      return
+    }
+
+    onSelectSite(result)
+
     console.log({ result })
-  }, [onSelect])
+  }, [onSelectSite])
 
   return <button onClick={browse} {...props} />
 }

--- a/src/components/site-preview.tsx
+++ b/src/components/site-preview.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react"
+import React, { PropsWithChildren, useCallback } from "react"
 import { GatsbySite } from "../controllers/site"
 import { useSiteRunnerStatus } from "./site-runners"
 
@@ -8,14 +8,30 @@ interface IProps {
 
 export function SitePreview({ site }: PropsWithChildren<IProps>): JSX.Element {
   const { logs, status } = useSiteRunnerStatus(site)
+
+  const stop = useCallback(() => site?.stop(), [site])
+  const start = useCallback(() => site?.start(), [site])
+
   return (
     <section>
+      <p>{site.packageJson?.name ?? `Unnamed site`}</p>
       <p>Status: {status}</p>
-      <ul>
-        {logs?.map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
+      {/* TODO: We can do this better by properly keeping track of running status */}
+      {!status || [`STOPPED`, `FAILED`, `INTERRUPTED`].includes(status) ? (
+        <button onClick={start}>Start</button>
+      ) : (
+        <button onClick={stop}>Stop</button>
+      )}
+
+      {!!logs?.length && (
+        <details>
+          <ul>
+            {logs?.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </details>
+      )}
     </section>
   )
 }

--- a/src/components/site-preview.tsx
+++ b/src/components/site-preview.tsx
@@ -6,6 +6,10 @@ interface IProps {
   site: GatsbySite
 }
 
+/**
+ * The item in the list of sites
+ */
+
 export function SitePreview({ site }: PropsWithChildren<IProps>): JSX.Element {
   const { logs, status } = useSiteRunnerStatus(site)
 

--- a/src/components/site-preview.tsx
+++ b/src/components/site-preview.tsx
@@ -18,7 +18,7 @@ export function SitePreview({ site }: PropsWithChildren<IProps>): JSX.Element {
 
   return (
     <section>
-      <p>{site.packageJson?.name ?? `Unnamed site`}</p>
+      <p>{site?.packageJson?.name ?? `Unnamed site`}</p>
       <p>Status: {status}</p>
       {/* TODO: We can do this better by properly keeping track of running status */}
       {!status || [`STOPPED`, `FAILED`, `INTERRUPTED`].includes(status) ? (

--- a/src/components/site-runners.tsx
+++ b/src/components/site-runners.tsx
@@ -9,6 +9,10 @@ import React, {
 import { GatsbySite, ISiteInfo } from "../controllers/site"
 import { Action } from "../util/ipc-types"
 
+/**
+ * This module uses shared context to store the list of user sites.
+ */
+
 interface IRunnerContext {
   sites: Map<string, GatsbySite>
   addSite?: (site: GatsbySite) => void
@@ -17,7 +21,9 @@ interface IRunnerContext {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const RunnerContext = createContext<IRunnerContext>({ sites: new Map() })
-
+/**
+ * Wraps the site root element in gatsby-browser
+ */
 export function RunnerProvider({
   children,
 }: {
@@ -47,6 +53,9 @@ export function RunnerProvider({
   )
 }
 
+/**
+ * Handles the list of sites, and functions to add and remove them
+ */
 export function useSiteRunners(): {
   sites: Map<string, GatsbySite>
   addSite: (siteInfo: ISiteInfo) => GatsbySite | undefined
@@ -68,6 +77,9 @@ export function useSiteRunners(): {
   return { sites, addSite }
 }
 
+/**
+ * Gets the status of an individual site
+ */
 export function useSiteRunnerStatus(
   theSite: GatsbySite
 ): { logs: Array<string>; status: string | undefined } {

--- a/src/controllers/site.ts
+++ b/src/controllers/site.ts
@@ -8,6 +8,10 @@ export interface ISiteInfo {
   packageJson: PackageJson
   warning?: string
 }
+
+/**
+ * Represents a single user Gatsby site
+ */
 export class GatsbySite {
   runner?: Worker
   logs: Array<string> = []
@@ -23,6 +27,11 @@ export class GatsbySite {
     this.root = siteInfo.path
     this.packageJson = siteInfo.packageJson
   }
+
+  /**
+   * Spawns a Worker to run `gateby develop` and sets up listeners to
+   * receive logs
+   */
 
   public start(): void {
     this.logs = []
@@ -62,6 +71,10 @@ export class GatsbySite {
     this.runner = undefined
     this.status = `STOPPED`
   }
+
+  /**
+   * Handles structured logs from the site
+   */
 
   handleMessage(action: Action): void {
     console.log(`LOG`, action)

--- a/src/controllers/site.ts
+++ b/src/controllers/site.ts
@@ -1,31 +1,40 @@
 import type { IProgram } from "gatsby/internal"
 import { Action, StructuredEventType } from "../util/ipc-types"
+import { PackageJson } from "gatsby"
 const workerUrl = `/launcher.js`
 
+export interface ISiteInfo {
+  path: string
+  packageJson: PackageJson
+  warning?: string
+}
 export class GatsbySite {
   runner?: Worker
   logs: Array<string> = []
-  status?: string
-
+  status = `STOPPED`
+  root: string
+  packageJson: PackageJson
   activities = new Map<string, any>()
+  port?: number
 
   private _listeners = new Set<(action: Action, site: GatsbySite) => void>()
 
-  constructor(public root: string) {}
+  constructor(siteInfo: ISiteInfo) {
+    this.root = siteInfo.path
+    this.packageJson = siteInfo.packageJson
+  }
 
   public start(): void {
+    this.logs = []
+    this.activities.clear()
+    this.status = `STARTING`
     const program: Partial<IProgram> = {
       directory: this.root,
     }
-    if (!program.directory) {
-      console.error(`No valid directory`)
-      return
-    }
+    this.runner = new Worker(workerUrl)
 
-    const runner = new Worker(workerUrl)
-
-    runner.postMessage({ type: `launch`, program })
-    runner.onmessage = (e): void => {
+    this.runner.postMessage({ type: `launch`, program })
+    this.runner.onmessage = (e): void => {
       console.log(`Message received from worker`, e.data)
       if (e.data?.type === `message` && e.data?.message?.type == `LOG_ACTION`) {
         this.handleMessage(e.data?.message?.action)
@@ -51,6 +60,7 @@ export class GatsbySite {
     }
     this.runner.postMessage({ type: `stop` })
     this.runner = undefined
+    this.status = `STOPPED`
   }
 
   handleMessage(action: Action): void {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,48 +1,20 @@
-import React, { useCallback, useState } from "react"
-import { useSiteRunners, RunnerProvider } from "../components/site-runners"
-import { GatsbySite } from "../controllers/site"
+import React from "react"
+import { useSiteRunners } from "../components/site-runners"
 import { SitePreview } from "../components/site-preview"
 import { SiteBrowser } from "../components/site-browser"
 
-const root = `/Users/matt/Repos/trexible`
-
 export default function App(): JSX.Element {
-  console.log(`GATSBY!`)
-
   const { addSite, sites } = useSiteRunners()
 
-  const [site, setSite] = useState<GatsbySite>()
-
-  const { logs, status } = site ?? { logs: [], status: `Loading` }
-  console.log({ logs, status })
-  const launch = useCallback(() => {
-    const newSite = addSite(root)
-    newSite?.start()
-    console.log({ newSite })
-    setSite(newSite)
-  }, [setSite])
-
-  const stop = useCallback(() => {
-    site?.stop()
-  }, [site])
-
   return (
-    <RunnerProvider>
-      <div>
-        <h1>💜 OMG Gatsby! 💜</h1>
-        <SiteBrowser onSelect={(): void => {}}>
-          Browse for a Gatsby site
-        </SiteBrowser>
-        {site ? (
-          <button onClick={stop}>Stop</button>
-        ) : (
-          <button onClick={launch}>Launch</button>
-        )}
-
-        {[...sites.values()].map((site) => (
-          <SitePreview key={site.root} site={site} />
-        ))}
-      </div>
-    </RunnerProvider>
+    <div>
+      <h1>💜 OMG Gatsby! 💜</h1>
+      <SiteBrowser onSelectSite={addSite} onSiteError={alert}>
+        Browse for a Gatsby site
+      </SiteBrowser>
+      {[...sites.values()].map((site) => (
+        <SitePreview key={site.root} site={site} />
+      ))}
+    </div>
   )
 }

--- a/src/util/ipc-types.ts
+++ b/src/util/ipc-types.ts
@@ -1,6 +1,11 @@
 /* eslint-disable camelcase */
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable quotes */
+
+/**
+ * Structured logs types. This is taken from Cloud.
+ */
+
 export enum StructuredLogLevel {
   Log = `LOG`,
   Warning = `WARNING`,

--- a/worker/launcher.ts
+++ b/worker/launcher.ts
@@ -70,10 +70,13 @@ async function launchSite(program: IProgram): Promise<number> {
 
   console.log(`Running on port ${port}`)
 
+  // Runs `gatsby develop` in the site root
   proc = spawn(
     path.join(program.directory, `node_modules`, `.bin`, `gatsby`),
     [`develop`, `--port=${port}`],
     {
+      // The Gatsby process detects the IPC channel and uses it to send
+      // structured logs
       stdio: [`pipe`, `pipe`, `pipe`, `ipc`],
       cwd: program.directory,
     }
@@ -89,6 +92,7 @@ async function launchSite(program: IProgram): Promise<number> {
   return port
 }
 
+// Messages from the parent renderer window
 onmessage = async (message: DevelopEvent): Promise<void> => {
   const { data } = message
   switch (data.type) {

--- a/worker/launcher.ts
+++ b/worker/launcher.ts
@@ -4,6 +4,12 @@ import { spawn, ChildProcess } from "child_process"
 import type { PackageJson } from "gatsby"
 import path from "path"
 import detectPort from "detect-port"
+
+/**
+ * This is a Worker, spawned by the main renderer process. There is one of these
+ * spawned for each user site that we launch. It handles the actual long-runnning
+ * `gatsby develop` process.
+ */
 interface ILaunchEventPayload {
   type: "launch"
   program: IProgram
@@ -20,7 +26,6 @@ interface ILaunchEvent extends MessageEvent {
 type DevelopEvent = IStopEvent | ILaunchEvent
 
 async function readJSON<T = unknown>(filePath: string): Promise<T> {
-  console.log(`reading`, filePath)
   return new Promise((resolve, reject) => {
     fs.readFile(filePath, `utf8`, (err, data) => {
       if (err) {
@@ -36,24 +41,23 @@ async function isGatsbySite(root: string): Promise<boolean> {
     const packageJson = await readJSON<PackageJson>(
       `/${root}/node_modules/gatsby/package.json`
     )
-    console.log({ packageJson })
-    return packageJson.name === `gatsby`
+    return packageJson?.name === `gatsby`
   } catch (e) {
-    console.log({ e })
+    console.warn({ e })
     return false
   }
 }
 
 let proc: ChildProcess | undefined
 
-async function launchSite(program: IProgram): Promise<void | ChildProcess> {
+async function launchSite(program: IProgram): Promise<number> {
   if (!(await isGatsbySite(program.directory))) {
     postMessage({
       type: `error`,
       message: `${program.directory} is not a Gatsby site`,
     })
     console.log(`Not a gatsby site`)
-    return void 0
+    return 0
   }
   console.log(`Is a gatsby site. Launching`)
 
@@ -82,20 +86,23 @@ async function launchSite(program: IProgram): Promise<void | ChildProcess> {
   proc.stdout?.on(`data`, (data) => console.log(data))
 
   proc.on(`message`, (message) => postMessage({ type: `message`, message }))
-  return proc
+  return port
 }
 
 onmessage = async (message: DevelopEvent): Promise<void> => {
-  console.log(`received`, message)
   const { data } = message
-  switch (data?.type) {
+  switch (data.type) {
     case `launch`:
-      console.log(`launching`)
       await launchSite(data.program)
       postMessage(`Hi`)
       break
 
     case `stop`:
-      proc?.kill()
+      if (proc?.connected) {
+        proc.kill()
+        proc = undefined
+      } else {
+        console.log(`Not running`)
+      }
   }
 }


### PR DESCRIPTION
This PR adds support for browsing for sites to add to Desktop. It stores a list of these sites in React context. 

When choosing a directory, we check if it is a Gatsby site first be seeing if Gatsby is in node_modules (= all good), or if not, whether Gatsby is a dependency (= needs dependencies installing). We still add it if needs installing, because eventually we can run yarn or npm for them. 

If the site is a Gatsby site then we grab the package.json (currently for the site name), and add the site to our list. We don't immediately launch it.