### PR TITLE
fix: missing PATH on Mac

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -37,6 +37,20 @@ async function start(): Promise<void> {
     },
   })
 
+  const childPids = new Set<number>()
+
+  ipcMain.on(`add-child-pid`, (event, payload: number) => {
+    childPids.add(payload)
+  })
+
+  ipcMain.on(`remove-child-pid`, (event, payload: number) => {
+    childPids.delete(payload)
+  })
+
+  app.on(`before-quit`, () => {
+    childPids.forEach((pid) => process.kill(pid))
+  })
+
   ipcMain.on(`quit-app`, () => {
     app.quit()
   })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "detect-port": "^1.3.0",
     "execa": "^4.0.3",
     "express": "^4.17.1",
+    "fix-path": "^3.0.0",
     "formik": "^2.1.5",
     "fs-extra": "^9.0.1",
     "gatsby": "^2.24.13",
@@ -24,6 +25,7 @@
     "react-dom": "^16.13.1",
     "react-icons": "^3.10.0",
     "serve-static": "^1.14.1",
+    "spawn-sync": "^2.0.0",
     "theme-ui": "0.4.0-rc.1"
   },
   "devDependencies": {

--- a/src/controllers/site.ts
+++ b/src/controllers/site.ts
@@ -41,6 +41,7 @@ export interface IWorkerAction {
 
 export interface ISiteStatus {
   logs: Array<string>
+  rawLogs: Array<string>
   status: Status
   activities: Map<string, any>
   running: boolean
@@ -50,6 +51,7 @@ export interface ISiteStatus {
 
 const DEFAULT_STATUS: ISiteStatus = {
   logs: [],
+  rawLogs: [],
   status: GlobalStatus.NotStarted,
   activities: new Map<string, any>(),
   running: false,
@@ -244,7 +246,9 @@ export class GatsbySite {
         break
 
       case WorkerActionType.rawLog:
-        this.logMessage(String(action.payload))
+        this.updateStatus({
+          rawLogs: this.siteStatus.rawLogs.concat(String(action.payload)),
+        })
         break
 
       default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,14 @@ cross-spawn@5.1.0, cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4466,6 +4474,11 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
+
+default-shell@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
+  integrity sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -5436,6 +5449,19 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  integrity sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -5846,6 +5872,13 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+fix-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fix-path/-/fix-path-3.0.0.tgz#c6b82fd5f5928e520b392a63565ebfef0ddf037e"
+  integrity sha512-opGAl4+ip5jUikHR2C8Jo7czZ80pz8EK/0gMlAZu7xgDmBqIynlX8SMYg9KowYjAU6HT0nxsSJEWru0u+n+N2Q==
+  dependencies:
+    shell-path "^2.1.0"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -6420,6 +6453,14 @@ get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
@@ -11619,6 +11660,22 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-env@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
+  integrity sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=
+  dependencies:
+    default-shell "^1.0.0"
+    execa "^0.5.0"
+    strip-ansi "^3.0.0"
+
+shell-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/shell-path/-/shell-path-2.1.0.tgz#ea7d06ae1070874a1bac5c65bb9bdd62e4f67a38"
+  integrity sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=
+  dependencies:
+    shell-env "^0.3.0"
+
 shell-quote@1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
@@ -11879,6 +11936,11 @@ space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
+
+spawn-sync@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-2.0.0.tgz#3af5ba4b73cc5dc8a41d3747eede71e98d949555"
+  integrity sha512-AGXIhH/XZVinFewojYTsG8uapHX2e7MjtFbmibvK9qqG4qGd9b6jelU1sTkCA0RVGHvN9exJYTBVbF1Ls2f69g==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
When launched as an installed App, macOS doesn't send a full `$PATH` in env. This was causing the spawned process to fail, as it couldn't find Node. This PR sets up the correct `PATH` so that it works again.

It also keeps track of spawned child pids so that it can terminate them on quit, and it sends raw logs to the controller so we can track them later (I used this to track down the bug).