### PR TITLE
Wire up onboarding settings

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -7,6 +7,7 @@ import {
   Tray,
   Menu,
   Event,
+  shell,
 } from "electron"
 import detectPort from "detect-port"
 import express from "express"
@@ -73,6 +74,11 @@ async function start(): Promise<void> {
         mainWindow.loadURL(makeUrl(`sites`))
       }
     }
+    // Intercept window.open/target=_blank from admin and open in browser
+    mainWindow.webContents.on(`new-window`, (event, url) => {
+      event.preventDefault()
+      shell.openExternal(url)
+    })
     mainWindow.show()
   }
 

--- a/src/components/onboarding/choose-editor.tsx
+++ b/src/components/onboarding/choose-editor.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import React, { useCallback } from "react"
 import { Button } from "gatsby-interface"
 import { MdArrowForward } from "react-icons/md"
 import {
@@ -9,6 +9,8 @@ import {
   IProps as WizardStepProps,
 } from "./onboarding-wizard-step"
 import { EditorsRadioButton } from "./editors-radio-button"
+import { ALL_EDITORS, CodeEditor } from "../../util/editors"
+import { useConfig } from "../../util/use-config"
 
 export interface IProps
   extends Pick<WizardStepProps, "currentStep" | "totalSteps"> {
@@ -20,15 +22,26 @@ export function ChooseEditor({
   totalSteps,
   onGoNext,
 }: IProps): JSX.Element {
-  const [preferredEditor, setPreferredEditor] = React.useState<string>(``)
-  const onSubmit: React.FocusEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault()
+  const [preferredEditor = ``, setPreferredEditor] = useConfig(
+    `preferredEditor`
+  )
+  const onSubmit: React.FocusEventHandler<HTMLFormElement> = useCallback(
+    (e) => {
+      e.preventDefault()
+      onGoNext()
+    },
+    [onGoNext]
+  )
 
-    // TODO do something with preferredEditor
-    console.log(preferredEditor)
+  console.log({ preferredEditor })
 
-    onGoNext()
-  }
+  const chooseEditor = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      console.log(`choosing editor `, event.target.value)
+      setPreferredEditor(event.target.value as CodeEditor)
+    },
+    [setPreferredEditor]
+  )
 
   return (
     <OnboardingWizardStep
@@ -40,20 +53,9 @@ export function ChooseEditor({
       <form onSubmit={onSubmit}>
         <EditorsRadioButton
           name="preferredEditor"
-          editors={[
-            `code`,
-            `sublime`,
-            `atom`,
-            `webstorm`,
-            `phpstorm`,
-            `idea14ce`,
-            `vim`,
-            `emacs`,
-            `visualstudio`,
-          ]}
-          onChange={(e): void => {
-            setPreferredEditor(e.target.value)
-          }}
+          editors={ALL_EDITORS}
+          onChange={chooseEditor}
+          selected={preferredEditor}
         />
         <OnboardingWizardStepActions>
           <Button

--- a/src/components/onboarding/editors-radio-button.tsx
+++ b/src/components/onboarding/editors-radio-button.tsx
@@ -18,6 +18,7 @@ export interface IProps {
   onChange?: React.ChangeEventHandler<HTMLInputElement>
   required?: boolean
   error?: React.ReactNode
+  selected?: CodeEditor | ""
 }
 
 export function EditorsRadioButton({
@@ -26,6 +27,7 @@ export function EditorsRadioButton({
   onChange,
   required,
   error,
+  selected = ``,
 }: IProps): JSX.Element {
   const {
     getLegendProps,
@@ -57,6 +59,7 @@ export function EditorsRadioButton({
                   value={optionValue}
                   onChange={onChange}
                   name={name}
+                  checked={editor === selected}
                   css={{
                     // TODO remove this temp fix once this is fixed in gatsby-interface
                     "& + span::before": {

--- a/src/components/onboarding/sites-checkbox-group.tsx
+++ b/src/components/onboarding/sites-checkbox-group.tsx
@@ -17,6 +17,7 @@ export interface IProps {
   sites: GatsbySite[]
   required?: boolean
   error?: React.ReactNode
+  hiddenSites: Array<string>
 }
 
 export function SiteCheckboxGroup({
@@ -24,6 +25,7 @@ export function SiteCheckboxGroup({
   sites,
   required,
   error,
+  hiddenSites = [],
 }: IProps): JSX.Element {
   const {
     getLegendProps,
@@ -43,18 +45,19 @@ export function SiteCheckboxGroup({
       />
       <Grid columns={[null, 1, 1, `repeat(auto-fit, 300px)`]} gap={7}>
         {sites.map((site) => {
-          console.log(site)
           const optionValue = site.hash
-
+          const hidden = hiddenSites.includes(optionValue)
           return (
             <GroupInputCard
-              key={optionValue}
+              // We need this because we do an initial render before the config comes through
+              // and if the key is the same it won't re-render the checkbox with the new default
+              key={`${optionValue}${hidden}`}
               {...getOptionLabelProps(optionValue)}
               input={
                 <StyledCheckbox
                   {...getOptionControlProps(optionValue)}
                   value={optionValue}
-                  defaultChecked
+                  defaultChecked={!hidden}
                   name={name}
                   css={{
                     // TODO remove this temp fix once this is fixed in gatsby-interface

--- a/src/components/site-card/editor-launcher.tsx
+++ b/src/components/site-card/editor-launcher.tsx
@@ -3,7 +3,7 @@ import { jsx } from "theme-ui"
 import { IconButton, Tooltip } from "gatsby-interface"
 import { useCallback, useMemo } from "react"
 import openInEditor from "open-in-editor"
-import { editorIcons, CodeEditor } from "../../util/editors"
+import { editorIcons, CodeEditor, editorLabels } from "../../util/editors"
 
 export interface IProps {
   path: string
@@ -19,7 +19,10 @@ export function EditorLauncher({ path, editor = `code` }: IProps): JSX.Element {
     editorInstance.open(path)
   }, [editorInstance])
   return (
-    <Tooltip label="Open in editor" sx={{ fontFamily: `sans`, fontSize: 0 }}>
+    <Tooltip
+      label={`Open in ${editorLabels[editor]}`}
+      sx={{ fontFamily: `sans`, fontSize: 0 }}
+    >
       <IconButton
         onClick={openEditor}
         variant="GHOST"

--- a/src/components/site-card/editor-launcher.tsx
+++ b/src/components/site-card/editor-launcher.tsx
@@ -7,7 +7,7 @@ import { editorIcons, CodeEditor } from "../../util/editors"
 
 export interface IProps {
   path: string
-  editor: CodeEditor
+  editor?: CodeEditor
 }
 
 export function EditorLauncher({ path, editor = `code` }: IProps): JSX.Element {

--- a/src/components/site-card/site-card.tsx
+++ b/src/components/site-card/site-card.tsx
@@ -17,6 +17,7 @@ import {
   siteDisplayStatusLabels,
 } from "../../util/site-status"
 import { visuallyHiddenCss } from "../../util/a11y"
+import { useConfig } from "../../util/use-config"
 
 interface IProps {
   site: GatsbySite
@@ -40,6 +41,8 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
 
   console.log(site.name, status)
   const displayStatus = getSiteDisplayStatus(status)
+
+  const [editor] = useConfig(`preferredEditor`)
 
   return (
     <Flex
@@ -105,7 +108,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
           </Flex>
         </Flex>
         <Flex mt="auto">
-          <EditorLauncher path={site.root} editor="code" />
+          <EditorLauncher path={site.root} editor={editor} />
         </Flex>
       </Flex>
       <button

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -5,19 +5,25 @@ import { Heading, Text, CheckboxFieldBlock, Button } from "gatsby-interface"
 import { OnboardingIllustration } from "../../components/onboarding/onboarding-illustration"
 import { MdArrowForward } from "react-icons/md"
 import { navigate } from "gatsby"
+import { useCallback, FormEvent } from "react"
+import { useConfig } from "../../util/use-config"
 
 export default function OnboardingMainPage(): JSX.Element {
   const onSubmit: React.FocusEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault()
-    const submitAnonUsageInfo = (e.currentTarget
-      .elements as HTMLFormControlsCollection & { anonUsage: HTMLInputElement })
-      .anonUsage.checked
-
-    // TODO do something with the checkbox value
-    console.log({ submitAnonUsageInfo })
-
     navigate(`/onboarding/editor`)
   }
+
+  const [optedIn = false, setOptedIn] = useConfig(`telemetryOptIn`)
+
+  console.log({ optedIn })
+
+  const onToggle = useCallback(
+    (e: FormEvent<HTMLInputElement>): void => {
+      setOptedIn(!e.currentTarget.checked)
+    },
+    [setOptedIn]
+  )
 
   return (
     <Grid
@@ -78,6 +84,8 @@ export default function OnboardingMainPage(): JSX.Element {
             id="anonUsage"
             name="anonUsage"
             label="Yes, submit anonymous usage information"
+            onInput={onToggle}
+            checked={optedIn}
             css={{
               // TODO remove this temp fix once this is fixed in gatsby-interface
               "input + span::before": {

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -20,7 +20,7 @@ export default function OnboardingMainPage(): JSX.Element {
 
   const onToggle = useCallback(
     (e: FormEvent<HTMLInputElement>): void => {
-      setOptedIn(!e.currentTarget.checked)
+      setOptedIn(e.currentTarget.checked)
     },
     [setOptedIn]
   )
@@ -84,7 +84,7 @@ export default function OnboardingMainPage(): JSX.Element {
             id="anonUsage"
             name="anonUsage"
             label="Yes, submit anonymous usage information"
-            onInput={onToggle}
+            onChange={onToggle}
             checked={optedIn}
             css={{
               // TODO remove this temp fix once this is fixed in gatsby-interface

--- a/src/pages/sites/[hash].tsx
+++ b/src/pages/sites/[hash].tsx
@@ -29,7 +29,7 @@ export default function SitePage({ params }: IProps): JSX.Element {
       {running && port ? (
         <iframe
           frameBorder={0}
-          src={`http://localhost:${port}/___admin`}
+          src={`http://localhost:${port}/___admin/`}
           sx={{
             flex: 1,
           }}

--- a/src/util/editors.tsx
+++ b/src/util/editors.tsx
@@ -29,6 +29,18 @@ export type CodeEditor =
   | "emacs"
   | "visualstudio"
 
+export const ALL_EDITORS: CodeEditor[] = [
+  `code`,
+  `sublime`,
+  `atom`,
+  `webstorm`,
+  `phpstorm`,
+  `idea14ce`,
+  `vim`,
+  `emacs`,
+  `visualstudio`,
+]
+
 export const editorLabels: Record<CodeEditor, string> = {
   atom: `Atom`,
   emacs: `Emacs`,

--- a/src/util/site-runners.tsx
+++ b/src/util/site-runners.tsx
@@ -134,9 +134,17 @@ export function RunnerProvider({
 export function useSiteRunners(): {
   // An array of sites, sorted in reverse order by last launched
   sites: Array<GatsbySite>
+  // Excludes hidden sites
+  filteredSites: Array<GatsbySite>
   addSite?: (siteInfo: ISiteInfo) => GatsbySite | undefined
 } {
-  return useContext(RunnerContext)
+  const { sites, addSite } = useContext(RunnerContext)
+  const [hiddenSites] = useConfig(`hiddenSites`)
+  const filteredSites = sites.filter(
+    (site) => !hiddenSites?.includes(site.hash)
+  )
+
+  return { sites, addSite, filteredSites }
 }
 
 /**
@@ -146,6 +154,27 @@ export function useSiteRunners(): {
 export function useSiteForHash(hash: string): GatsbySite | undefined {
   const { sites } = useSiteRunners()
   return sites.find((site) => site.hash === hash)
+}
+
+/**
+ * Handles the list of hidden sites
+ */
+
+export function useHiddenSites(): {
+  hiddenSites: Array<string>
+  hideSite: (siteHash: string) => void
+  unhideSite: (siteHash: string) => void
+  setHiddenSites: (siteHashes: Array<string>) => void
+} {
+  const [hiddenSites = [], setHiddenSites] = useConfig(`hiddenSites`)
+
+  const hideSite = (siteHash: string): void =>
+    setHiddenSites(Array.from(new Set([...hiddenSites, siteHash])))
+
+  const unhideSite = (siteHash: string): void =>
+    setHiddenSites(hiddenSites.filter((site) => site !== siteHash))
+
+  return { hiddenSites, hideSite, unhideSite, setHiddenSites }
 }
 
 /**

--- a/src/util/use-config.tsx
+++ b/src/util/use-config.tsx
@@ -6,6 +6,7 @@ import React, {
   ReactNode,
   useContext,
 } from "react"
+import { CodeEditor } from "./editors"
 
 /**
  * This module uses shared context to wrap and subscribe to electron-config
@@ -13,6 +14,9 @@ import React, {
 
 interface IConfigType {
   siteTabs: Array<string>
+  chosenSites: Array<string>
+  telemetryOptIn: boolean
+  preferredEditor: CodeEditor
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/util/use-config.tsx
+++ b/src/util/use-config.tsx
@@ -14,7 +14,7 @@ import { CodeEditor } from "./editors"
 
 interface IConfigType {
   siteTabs: Array<string>
-  chosenSites: Array<string>
+  hiddenSites: Array<string>
   telemetryOptIn: boolean
   preferredEditor: CodeEditor
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
-brace-expansion@^1.0.0, brace-expansion@^1.1.7:
+brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
@@ -4649,6 +4649,8 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
@@ -7380,16 +7382,6 @@ hosted-git-info@^3.0.4, hosted-git-info@^3.0.5:
   dependencies:
     lru-cache "^6.0.0"
 
-hpack.js@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
-  integrity sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=
-  dependencies:
-    inherits "^2.0.1"
-    obuf "^1.0.0"
-    readable-stream "^2.0.1"
-    wbuf "^1.1.0"
-
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -9187,13 +9179,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  integrity sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
-  dependencies:
-    brace-expansion "^1.0.0"
-
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -9691,11 +9676,6 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-obuf@^1.0.0, obuf@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
-  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11220,7 +11200,7 @@ read@^1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -11259,6 +11239,8 @@ recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
   integrity sha1-kO8jHQd4xc4JPJpI105cVCLROpk=
+  dependencies:
+    minimatch "3.0.3"
 
 redux-thunk@^2.3.0:
   version "2.3.0"
@@ -12364,6 +12346,13 @@ spdy-transport@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
   integrity sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==
+  dependencies:
+    debug "^4.1.0"
+    detect-node "^2.0.4"
+    hpack.js "^2.1.6"
+    obuf "^1.1.2"
+    readable-stream "^3.0.6"
+    wbuf "^1.7.3"
 
 spdy@^4.0.2:
   version "4.0.2"
@@ -13653,13 +13642,6 @@ watchpack@^1.6.1:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
-
-wbuf@^1.1.0, wbuf@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
-  integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
-  dependencies:
-    minimalistic-assert "^1.0.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
This PR persists the preferences for:
- telemetry (though doesn't do anything with this, as we're not currently sending any)
- preferred code editor (and uses this)
- selected sites. This is actually implemented as persisting a list of *hidden* sites, because the source of truth is the auto-discovered site list

[ch14606]