### PR TITLE
Fix window size and run onboarding flow

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -37,6 +37,7 @@ function makeWindow(): BrowserWindow {
     titleBarStyle: `hidden`,
     width: 1024,
     height: 768,
+    backgroundColor: `#452475`, // purple.80
     fullscreenable: false,
     show: !process.env.GATSBY_DEVELOP_URL,
     trafficLightPosition: { x: 8, y: 18 },
@@ -59,7 +60,7 @@ async function start(): Promise<void> {
     .use(serveStatic(path.resolve(dir, `public`)))
     .listen(port)
 
-  const makeUrl = (path: string): string =>
+  const makeUrl = (path: string = ``): string =>
     process.env.GATSBY_DEVELOP_URL
       ? `${process.env.GATSBY_DEVELOP_URL}/${path}`
       : `http://localhost:${port}/${path}`
@@ -73,10 +74,10 @@ async function start(): Promise<void> {
   function openMainWindow(): void {
     if (!mainWindow || mainWindow.isDestroyed()) {
       mainWindow = makeWindow()
-      mainWindow.loadURL(makeUrl(`sites`))
+      mainWindow.loadURL(makeUrl())
     } else {
       if (!mainWindow.webContents.getURL()) {
-        mainWindow.loadURL(makeUrl(`sites`))
+        mainWindow.loadURL(makeUrl())
       }
     }
     // Intercept window.open/target=_blank from admin and open in browser
@@ -140,16 +141,16 @@ async function start(): Promise<void> {
     // If we're not running develop we can preload the start page
 
     if (!process.env.GATSBY_DEVELOP_URL) {
-      mainWindow.loadURL(makeUrl(`sites`))
+      mainWindow.loadURL(makeUrl())
       mainWindow.show()
     }
   })
-
+  // The `payload` can be a site id, which means the window will be opened with that site's admin page
   ipcMain.on(`open-main`, async (event, payload?: string) => {
     if (!mainWindow || mainWindow.isDestroyed()) {
       mainWindow = makeWindow()
     }
-    const url = makeUrl(payload ? `sites/${payload}` : `sites`)
+    const url = makeUrl(payload ? `sites/${payload}` : ``)
     if (mainWindow.webContents.getURL() !== url) {
       mainWindow.loadURL(url)
     }

--- a/app/main.ts
+++ b/app/main.ts
@@ -35,6 +35,8 @@ function makeWindow(): BrowserWindow {
   return new BrowserWindow({
     title: `Gatsby Desktop`,
     titleBarStyle: `hidden`,
+    width: 1024,
+    height: 768,
     fullscreenable: false,
     show: !process.env.GATSBY_DEVELOP_URL,
     trafficLightPosition: { x: 8, y: 18 },

--- a/src/components/folder-name.tsx
+++ b/src/components/folder-name.tsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
-import { jsx } from "theme-ui"
-import { Text } from "gatsby-interface"
+import { jsx, Flex } from "theme-ui"
 import { MdFolderOpen } from "react-icons/md"
 import path from "path"
 
@@ -11,22 +10,30 @@ export interface IProps {
 export function FolderName({ sitePath }: IProps): JSX.Element {
   const folder = path.basename(sitePath)
   return (
-    <Text
-      as="span"
+    <Flex
+      marginTop="2"
       sx={{
-        py: 2,
-        px: 1,
-        fontFamily: `sans`,
-        fontSize: 0,
-        lineHeight: `12px`,
-        color: `grey.60`,
-        display: `flex`,
         alignItems: `center`,
+        fontWeight: `body`,
+        color: `grey.60`,
+        fontSize: 0,
+        lineHeight: `default`,
       }}
     >
-      <MdFolderOpen size={12} aria-label="Folder:" />
-      {` `}
-      <span sx={{ paddingLeft: 2 }}>{folder}</span>
-    </Text>
+      <MdFolderOpen
+        sx={{ marginRight: 2, flexShrink: 0 }}
+        aria-label="Folder:"
+      />
+      <span
+        sx={{
+          minWidth: 0, // needed for text truncation to work properly
+          textOverflow: `ellipsis`,
+          whiteSpace: `nowrap`,
+          overflow: `hidden`,
+        }}
+      >
+        {folder}
+      </span>
+    </Flex>
   )
 }

--- a/src/components/onboarding/sites-checkbox-group.tsx
+++ b/src/components/onboarding/sites-checkbox-group.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, Grid, Flex } from "theme-ui"
+import { jsx, Grid } from "theme-ui"
 import { GatsbySite } from "../../controllers/site"
 import {
   useAriaFormGroupField,
@@ -8,9 +8,10 @@ import {
   FormError,
   StyledCheckbox,
 } from "gatsby-interface"
-import { MdFolderOpen, MdArrowForward } from "react-icons/md"
+import { MdArrowForward } from "react-icons/md"
 import { visuallyHiddenCss } from "../../util/a11y"
 import { GroupInputCard, GroupButtonCard } from "./group-input-card"
+import { FolderName } from "../folder-name"
 
 export interface IProps {
   name: string
@@ -72,28 +73,7 @@ export function SiteCheckboxGroup({
               sx={{ pl: 7 }}
             >
               {site.name}
-              <Flex
-                marginTop="2"
-                sx={{
-                  alignItems: `center`,
-                  fontWeight: `body`,
-                  color: `grey.60`,
-                  fontSize: 0,
-                  lineHeight: `default`,
-                }}
-              >
-                <MdFolderOpen sx={{ marginRight: 2, flexShrink: 0 }} />
-                <span
-                  sx={{
-                    minWidth: 0, // needed for text truncation to work properly
-                    textOverflow: `ellipsis`,
-                    whiteSpace: `nowrap`,
-                    overflow: `hidden`,
-                  }}
-                >
-                  {site.root.split(`/`).pop()}
-                </span>
-              </Flex>
+              <FolderName sitePath={site.root} />
             </GroupInputCard>
           )
         })}

--- a/src/components/site-card/logs-launcher.tsx
+++ b/src/components/site-card/logs-launcher.tsx
@@ -26,7 +26,7 @@ export function LogsLauncher({ logs, status }: IProps): JSX.Element {
         View logs
       </GhostButton>
       <Modal aria-label="Logs" isOpen={isOpen} onDismiss={toggleLogs}>
-        <ModalPanel>
+        <ModalPanel maxWidth="80%">
           <LogsViewer logs={logs} onDismiss={toggleLogs} />
         </ModalPanel>
       </Modal>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { useConfig } from "../util/use-config"
+import { navigate } from "gatsby"
+import { ReactNode } from "react"
+export default function Redirector(): ReactNode {
+  const [onboardingDone] = useConfig(`hasRunOnboarding`)
+  if (typeof window !== `undefined`) {
+    if (onboardingDone) {
+      navigate(`/sites`)
+    } else {
+      navigate(`/onboarding/intro`)
+    }
+  }
+
+  return (
+    <div
+      sx={{
+        width: `100vw`,
+        height: `100vh`,
+        backgroundColor: `purple.80`,
+      }}
+      onClick={(): Promise<void> => navigate(`/onboarding/intro`)}
+    />
+  )
+}

--- a/src/pages/onboarding/sites.tsx
+++ b/src/pages/onboarding/sites.tsx
@@ -4,18 +4,20 @@ import { navigate } from "gatsby"
 import { ChooseSites } from "../../components/onboarding/choose-sites"
 import { Layout } from "../../components/layout"
 import { OnboardingLayout } from "../../components/onboarding/onboarding-layout"
+import { useCallback } from "react"
+import { useConfig } from "../../util/use-config"
 
 export default function OnboardingSitesPage(): JSX.Element {
+  const [hasRunOnboarding, setOnboardingDone] = useConfig(`hasRunOnboarding`)
+
+  const onboardingDone = useCallback((): void => {
+    setOnboardingDone(true)
+    navigate(`/sites`)
+  }, [setOnboardingDone])
   return (
     <Layout>
       <OnboardingLayout>
-        <ChooseSites
-          currentStep={3}
-          totalSteps={3}
-          onGoNext={(): void => {
-            navigate(`/sites`)
-          }}
-        />
+        <ChooseSites currentStep={3} totalSteps={3} onGoNext={onboardingDone} />
       </OnboardingLayout>
     </Layout>
   )

--- a/src/pages/sites/[hash].tsx
+++ b/src/pages/sites/[hash].tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from "theme-ui"
+import { jsx, Flex } from "theme-ui"
 import { Text } from "gatsby-interface"
 import { useSiteRunnerStatus, useSiteForHash } from "../../util/site-runners"
 import { Layout } from "../../components/layout"
@@ -26,7 +26,7 @@ export default function SitePage({ params }: IProps): JSX.Element {
 
   return (
     <Layout>
-      <main>
+      <Flex>
         {running && port ? (
           <iframe
             frameBorder={0}
@@ -39,7 +39,7 @@ export default function SitePage({ params }: IProps): JSX.Element {
         ) : (
           <Text>Not running</Text>
         )}
-      </main>
+      </Flex>
     </Layout>
   )
 }

--- a/src/pages/sites/index.tsx
+++ b/src/pages/sites/index.tsx
@@ -5,9 +5,14 @@ import { SiteCard } from "../../components/site-card/site-card"
 import { Heading, Text, LinkButton } from "gatsby-interface"
 import { MdArrowForward } from "react-icons/md"
 import { Layout } from "../../components/layout"
+import { useConfig } from "../../util/use-config"
 
 export default function MainPage(): JSX.Element {
-  const { sites } = useSiteRunners()
+  const { filteredSites } = useSiteRunners()
+
+  const [onboardingDone, setHasRunOnboarding, store] = useConfig(
+    `hasRunOnboarding`
+  )
 
   return (
     <Layout>
@@ -27,10 +32,12 @@ export default function MainPage(): JSX.Element {
         >
           All sites{` `}
           <Text as="span" size="S">
-            ({sites.length})
+            ({filteredSites.length})
           </Text>
           <LinkButton
             to="/onboarding/intro"
+            // Easter egg: right click to clear config
+            onContextMenu={(): void => store?.clear()}
             size="S"
             variant="SECONDARY"
             rightIcon={<MdArrowForward />}
@@ -44,7 +51,7 @@ export default function MainPage(): JSX.Element {
           marginTop={7}
           columns="repeat(auto-fit, minmax(400px, 1fr))"
         >
-          {sites.map((site) => (
+          {filteredSites.map((site) => (
             <SiteCard key={site.hash} site={site} />
           ))}
         </Grid>

--- a/src/pages/sites/index.tsx
+++ b/src/pages/sites/index.tsx
@@ -42,7 +42,7 @@ export default function MainPage(): JSX.Element {
         <Grid
           gap={8}
           marginTop={7}
-          columns="repeat(auto-fit, minmax(480px, 1fr))"
+          columns="repeat(auto-fit, minmax(400px, 1fr))"
         >
           {sites.map((site) => (
             <SiteCard key={site.hash} site={site} />


### PR DESCRIPTION
This creates a new root page that redirects to either the site list on onboarding if it's never been completed before. It sets the flag once onbaording is complete. For testing there's an easter egg: right click on the "onboarding" button and it clears the config store, including the onboarded flag.

This PR includes a couple of other small changes. It changes the default window size, and it uses a shared component to display the site folder name.