### PR TITLE
Structured logs and minor UI fixes/improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^9.0.1",
     "gatsby": "^2.24.47",
     "gatsby-design-tokens": "^2.0.10",
-    "gatsby-interface": "^0.0.194-Elanhant-minor-fixes-20200902T1627",
+    "gatsby-interface": "^0.0.196",
     "open-in-editor": "^2.2.0",
     "promisify-child-process": "^4.1.1",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fs-extra": "^9.0.1",
     "gatsby": "^2.24.47",
     "gatsby-design-tokens": "^2.0.10",
-    "gatsby-interface": "^0.0.193",
+    "gatsby-interface": "^0.0.194-Elanhant-minor-fixes-20200902T1627",
     "open-in-editor": "^2.2.0",
     "promisify-child-process": "^4.1.1",
     "react": "^16.13.1",

--- a/src/components/onboarding/editors-radio-button.tsx
+++ b/src/components/onboarding/editors-radio-button.tsx
@@ -60,12 +60,6 @@ export function EditorsRadioButton({
                   onChange={onChange}
                   name={name}
                   checked={editor === selected}
-                  css={{
-                    // TODO remove this temp fix once this is fixed in gatsby-interface
-                    "& + span::before": {
-                      boxSizing: `border-box`,
-                    },
-                  }}
                 />
               }
             >

--- a/src/components/onboarding/intro.tsx
+++ b/src/components/onboarding/intro.tsx
@@ -67,12 +67,6 @@ export function OnboardingIntro({ onGoNext }: IProps): JSX.Element {
           label="Yes, submit anonymous usage information"
           onChange={onToggle}
           checked={optedIn}
-          css={{
-            // TODO remove this temp fix once this is fixed in gatsby-interface
-            "input + span::before": {
-              boxSizing: `border-box`,
-            },
-          }}
         />
         <Button
           type="submit"

--- a/src/components/onboarding/sites-checkbox-group.tsx
+++ b/src/components/onboarding/sites-checkbox-group.tsx
@@ -62,12 +62,6 @@ export function SiteCheckboxGroup({
                   value={optionValue}
                   defaultChecked={!hidden}
                   name={name}
-                  css={{
-                    // TODO remove this temp fix once this is fixed in gatsby-interface
-                    "& + span::before": {
-                      boxSizing: `border-box`,
-                    },
-                  }}
                 />
               }
               sx={{ pl: 7 }}

--- a/src/components/site-card/logs-launcher.tsx
+++ b/src/components/site-card/logs-launcher.tsx
@@ -11,9 +11,10 @@ import { SiteStatusDot } from "../site-status-dot"
 export interface IProps {
   logs: Array<string>
   status: Status
+  siteName: string
 }
 
-export function LogsLauncher({ logs, status }: IProps): JSX.Element {
+export function LogsLauncher({ logs, status, siteName }: IProps): JSX.Element {
   const error = isErrored(status)
   const [isOpen, setIsOpen] = useState(false)
   const toggleLogs = useCallback((): void => {
@@ -27,7 +28,7 @@ export function LogsLauncher({ logs, status }: IProps): JSX.Element {
       </GhostButton>
       <Modal aria-label="Logs" isOpen={isOpen} onDismiss={toggleLogs}>
         <ModalPanel maxWidth="80%">
-          <LogsViewer logs={logs} onDismiss={toggleLogs} />
+          <LogsViewer logs={logs} siteName={siteName} onDismiss={toggleLogs} />
         </ModalPanel>
       </Modal>
     </Fragment>

--- a/src/components/site-card/logs-launcher.tsx
+++ b/src/components/site-card/logs-launcher.tsx
@@ -7,14 +7,21 @@ import { LogsViewer } from "./logs-viewer"
 import { isErrored } from "../../util/site-status"
 import { GhostButton } from "./ghost-button"
 import { SiteStatusDot } from "../site-status-dot"
+import { LogObject } from "../../util/ipc-types"
 
 export interface IProps {
+  structuredLogs: Array<LogObject>
   logs: Array<string>
   status: Status
   siteName: string
 }
 
-export function LogsLauncher({ logs, status, siteName }: IProps): JSX.Element {
+export function LogsLauncher({
+  structuredLogs,
+  logs,
+  status,
+  siteName,
+}: IProps): JSX.Element {
   const error = isErrored(status)
   const [isOpen, setIsOpen] = useState(false)
   const toggleLogs = useCallback((): void => {
@@ -27,8 +34,13 @@ export function LogsLauncher({ logs, status, siteName }: IProps): JSX.Element {
         View logs
       </GhostButton>
       <Modal aria-label="Logs" isOpen={isOpen} onDismiss={toggleLogs}>
-        <ModalPanel maxWidth="80%">
-          <LogsViewer logs={logs} siteName={siteName} onDismiss={toggleLogs} />
+        <ModalPanel css={{ width: `52rem` }} maxWidth="80%">
+          <LogsViewer
+            structuredLogs={structuredLogs}
+            logs={logs}
+            siteName={siteName}
+            onDismiss={toggleLogs}
+          />
         </ModalPanel>
       </Modal>
     </Fragment>

--- a/src/components/site-card/logs-viewer.tsx
+++ b/src/components/site-card/logs-viewer.tsx
@@ -1,15 +1,16 @@
 /** @jsx jsx */
-import { jsx } from "theme-ui"
+import { jsx, Flex } from "theme-ui"
 import { RawLogs, StyledPanel, StyledPanelHeader } from "gatsby-interface"
 import AnsiParser from "ansi-to-html"
 import { useMemo } from "react"
 
 export interface IProps {
   logs: Array<string>
+  siteName: string
   onDismiss: () => void
 }
 
-export function LogsViewer({ logs, onDismiss }: IProps): JSX.Element {
+export function LogsViewer({ logs, siteName, onDismiss }: IProps): JSX.Element {
   const parser = useMemo(
     () =>
       new AnsiParser({
@@ -20,23 +21,25 @@ export function LogsViewer({ logs, onDismiss }: IProps): JSX.Element {
 
   return (
     <StyledPanel>
-      <StyledPanelHeader onCloseButtonClick={onDismiss}>Logs</StyledPanelHeader>
-      <RawLogs
-        // RawLogs expect "message" to be a string but in factthey also support elements
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        logItems={logs.map((logEntry) => {
-          return {
-            message: (
-              <span
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                dangerouslySetInnerHTML={{ __html: parser.toHtml(logEntry) }}
-              />
-            ),
-          }
-        })}
-        aria-label="Logs"
-      />
+      <Flex sx={{ flexDirection: `column`, height: `100%` }}>
+        <StyledPanelHeader onCloseButtonClick={onDismiss}>
+          Logs for <strong sx={{ color: `blue.80` }}>{siteName}</strong>
+        </StyledPanelHeader>
+        <RawLogs
+          logItems={logs.map((logEntry) => {
+            return {
+              message: (
+                <span
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  dangerouslySetInnerHTML={{ __html: parser.toHtml(logEntry) }}
+                />
+              ),
+            }
+          })}
+          aria-label="Logs"
+          sx={{ flexGrow: 1 }}
+        />
+      </Flex>
     </StyledPanel>
   )
 }

--- a/src/components/site-card/logs-viewer.tsx
+++ b/src/components/site-card/logs-viewer.tsx
@@ -1,16 +1,37 @@
 /** @jsx jsx */
 import { jsx, Flex } from "theme-ui"
-import { RawLogs, StyledPanel, StyledPanelHeader } from "gatsby-interface"
+import {
+  RawLogs,
+  StyledPanel,
+  StyledPanelHeader,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  BuildLogsList,
+  BuildActivityType,
+  BuildActivityStatus,
+  StyledPanelBodySection,
+  BuildLogItem,
+} from "gatsby-interface"
 import AnsiParser from "ansi-to-html"
 import { useMemo } from "react"
+import { LogObject, ActivityType, ActivityLogLevel } from "../../util/ipc-types"
 
 export interface IProps {
+  structuredLogs: Array<LogObject>
   logs: Array<string>
   siteName: string
   onDismiss: () => void
 }
 
-export function LogsViewer({ logs, siteName, onDismiss }: IProps): JSX.Element {
+export function LogsViewer({
+  structuredLogs,
+  logs,
+  siteName,
+  onDismiss,
+}: IProps): JSX.Element {
   const parser = useMemo(
     () =>
       new AnsiParser({
@@ -19,27 +40,99 @@ export function LogsViewer({ logs, siteName, onDismiss }: IProps): JSX.Element {
     []
   )
 
+  console.log(`structuredLogs`, structuredLogs)
+
   return (
     <StyledPanel>
       <Flex sx={{ flexDirection: `column`, height: `100%` }}>
         <StyledPanelHeader onCloseButtonClick={onDismiss}>
-          Logs for <strong sx={{ color: `blue.80` }}>{siteName}</strong>
+          <strong sx={{ color: `blue.80` }}>{siteName}</strong>
         </StyledPanelHeader>
-        <RawLogs
-          logItems={logs.map((logEntry) => {
-            return {
-              message: (
-                <span
-                  // eslint-disable-next-line @typescript-eslint/naming-convention
-                  dangerouslySetInnerHTML={{ __html: parser.toHtml(logEntry) }}
+        <Tabs sx={{ flexGrow: 1, display: `flex`, flexDirection: `column` }}>
+          <TabList sx={{ flexGrow: 0 }}>
+            <Tab>Logs</Tab>
+            <Tab>Raw logs</Tab>
+          </TabList>
+          <TabPanels sx={{ flexGrow: 1 }}>
+            <TabPanel sx={{ height: `100%` }}>
+              <StyledPanelBodySection>
+                <BuildLogsList
+                  logItems={structuredLogs.map(logObjectToBuildLogItem)}
+                  aria-label="Logs"
+                  sx={{
+                    fontFamily: `sans`,
+                  }}
                 />
-              ),
-            }
-          })}
-          aria-label="Logs"
-          sx={{ flexGrow: 1 }}
-        />
+              </StyledPanelBodySection>
+            </TabPanel>
+            <TabPanel sx={{ height: `100%` }}>
+              <RawLogs
+                logItems={logs.map((logEntry) => {
+                  return {
+                    message: (
+                      <span
+                        dangerouslySetInnerHTML={{
+                          // eslint-disable-next-line @typescript-eslint/naming-convention
+                          __html: parser.toHtml(logEntry),
+                        }}
+                      />
+                    ),
+                  }
+                })}
+                aria-label="Raw Logs"
+                sx={{ height: `100%` }}
+              />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
       </Flex>
     </StyledPanel>
   )
+}
+
+const mapActivityTypeToBuildActivityType: Record<
+  ActivityType,
+  BuildActivityType
+> = {
+  [ActivityType.spinner]: BuildActivityType.Spinner,
+  [ActivityType.progress]: BuildActivityType.Progress,
+  [ActivityType.pending]: BuildActivityType.Pending,
+  [ActivityType.hidden]: BuildActivityType.Hidden,
+}
+
+const mapActivityLevelToBuildActivityStatus: Record<
+  ActivityLogLevel,
+  BuildActivityStatus
+> = {
+  [ActivityLogLevel.ActivityFailed]: BuildActivityStatus.Failed,
+  [ActivityLogLevel.ActivityInterrupted]: BuildActivityStatus.Interrupted,
+  [ActivityLogLevel.ActivitySuccess]: BuildActivityStatus.Success,
+}
+
+function logObjectToBuildLogItem(logObject: LogObject): BuildLogItem {
+  // Handle activity
+  if (`activity_uuid` in logObject) {
+    return {
+      id: logObject.activity_uuid,
+      message: logObject.text.trim(),
+      activity: {
+        id: logObject.activity_uuid,
+        type:
+          mapActivityTypeToBuildActivityType[
+            logObject.activity_type as ActivityType
+          ],
+        status: mapActivityLevelToBuildActivityStatus[logObject.level],
+        name: logObject.text,
+        duration: logObject.duration,
+        current: logObject.activity_current,
+        total: logObject.activity_total,
+      },
+    }
+  }
+
+  return {
+    ...logObject,
+    id: `${logObject.timestamp}-${logObject.text.substr(0, 12)}`,
+    message: logObject.text.trim(),
+  }
 }

--- a/src/components/site-card/site-card.tsx
+++ b/src/components/site-card/site-card.tsx
@@ -31,7 +31,9 @@ function canBeKilled(status: Status, pid?: number): boolean {
  * The item in the list of sites
  */
 export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
-  const { status, running, port, pid, rawLogs } = useSiteRunnerStatus(site)
+  const { status, running, port, pid, rawLogs, logs } = useSiteRunnerStatus(
+    site
+  )
 
   const { addTab } = useSiteTabs()
 
@@ -86,6 +88,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
             </div>
             {!!rawLogs?.length && (
               <LogsLauncher
+                structuredLogs={logs}
                 logs={rawLogs}
                 status={status}
                 siteName={site.name}

--- a/src/components/site-card/site-card.tsx
+++ b/src/components/site-card/site-card.tsx
@@ -51,6 +51,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
         border: `grey`,
         borderRadius: 2,
         boxShadow: `raised`,
+        whiteSpace: `pre`,
       }}
     >
       <StatusIndicator displayStatus={displayStatus} />
@@ -64,6 +65,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
               fontFamily: `sans`,
               fontWeight: 600,
               fontSize: 1,
+              pr: 3,
             }}
           >
             {site.name ?? `Unnamed site`}
@@ -73,15 +75,21 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
             <span css={visuallyHiddenCss}>
               Site status: {siteDisplayStatusLabels[displayStatus]}
             </span>
-            {displayStatus === SiteDisplayStatus.Running && !!port ? (
-              <SiteLauncher port={port} />
-            ) : displayStatus === SiteDisplayStatus.Starting ? (
-              <Text as="span" sx={{ fontSize: 0, color: `grey.60` }}>
-                Starting site...
-              </Text>
-            ) : null}
+            <div sx={{ mr: 3 }}>
+              {displayStatus === SiteDisplayStatus.Running && !!port ? (
+                <SiteLauncher port={port} />
+              ) : displayStatus === SiteDisplayStatus.Starting ? (
+                <Text as="span" sx={{ fontSize: 0, color: `grey.60` }}>
+                  Starting site...
+                </Text>
+              ) : null}
+            </div>
             {!!rawLogs?.length && (
-              <LogsLauncher logs={rawLogs} status={status} />
+              <LogsLauncher
+                logs={rawLogs}
+                status={status}
+                siteName={site.name}
+              />
             )}
             <SplitButton
               size="S"

--- a/src/components/site-status-dot.tsx
+++ b/src/components/site-status-dot.tsx
@@ -32,6 +32,7 @@ export function SiteStatusDot({ status, ...rest }: IProps): JSX.Element {
         width: 8,
         height: 8,
         borderRadius: 5,
+        flexShrink: 0,
         ...(displayStatus === SiteDisplayStatus.Stopped && {
           border: `grey`,
         }),

--- a/src/components/tab-navigation.tsx
+++ b/src/components/tab-navigation.tsx
@@ -75,10 +75,7 @@ export function SiteTabLink({ site, ...props }: ITabProps): JSX.Element {
       }}
     >
       <TabLink {...props} to={url}>
-        <SiteStatusDot
-          status={site.siteStatus.status}
-          sx={{ mr: 2, flexShrink: 0 }}
-        />
+        <SiteStatusDot status={site.siteStatus.status} sx={{ mr: 2 }} />
         {site.name}
       </TabLink>
       <button

--- a/src/pages/sites/index.tsx
+++ b/src/pages/sites/index.tsx
@@ -49,7 +49,7 @@ export default function MainPage(): JSX.Element {
         <Grid
           gap={8}
           marginTop={7}
-          columns="repeat(auto-fit, minmax(480px, 1fr))"
+          columns="repeat(auto-fit, minmax(456px, 1fr))"
         >
           {filteredSites.map((site) => (
             <SiteCard key={site.hash} site={site} />

--- a/src/pages/sites/index.tsx
+++ b/src/pages/sites/index.tsx
@@ -49,7 +49,7 @@ export default function MainPage(): JSX.Element {
         <Grid
           gap={8}
           marginTop={7}
-          columns="repeat(auto-fit, minmax(400px, 1fr))"
+          columns="repeat(auto-fit, minmax(480px, 1fr))"
         >
           {filteredSites.map((site) => (
             <SiteCard key={site.hash} site={site} />

--- a/src/util/ipc-types.ts
+++ b/src/util/ipc-types.ts
@@ -19,7 +19,7 @@ export enum JobsApiNames {
   ImageProcessing = `IMAGE_PROCESSING`,
 }
 
-enum ActivityLogLevel {
+export enum ActivityLogLevel {
   ActivitySuccess = `ACTIVITY_SUCCESS`,
   ActivityFailed = `ACTIVITY_FAILED`,
   ActivityInterrupted = `ACTIVITY_INTERRUPTED`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
-brace-expansion@^1.0.0, brace-expansion@^1.1.7:
+brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
@@ -6420,10 +6420,10 @@ gatsby-interface@^0.0.166:
     lodash.sample "^4.2.1"
     theme-ui "^0.2.49"
 
-gatsby-interface@^0.0.194-Elanhant-minor-fixes-20200902T1627:
-  version "0.0.194-Elanhant-minor-fixes-20200902T1627"
-  resolved "https://registry.npmjs.org/gatsby-interface/-/gatsby-interface-0.0.194-Elanhant-minor-fixes-20200902T1627.tgz#1837bab68be768502c50d4c044d34c0ff622774b"
-  integrity sha512-u/COdT6lYYcxAMbOMEdf+91daDskZkjwMO/baHKlOgWrudrEwmrobdX6Q4yl8EE7s9RQAz35T+GewLRS41zTrg==
+gatsby-interface@^0.0.196:
+  version "0.0.196"
+  resolved "https://registry.npmjs.org/gatsby-interface/-/gatsby-interface-0.0.196.tgz#4ea28777f52ac608258a3b4e70826ad954ceaf05"
+  integrity sha512-nDt2k7j98vspAjQKTf2cAr/tkc7as31wsa/GenNck2vZnN8yxJmlAWKoP9vePM/LXUPXoVo4KrA8bPp5j7I7aw==
   dependencies:
     "@mdx-js/react" "^1.5.2"
     "@reach/alert" "0.10.3"
@@ -7379,16 +7379,6 @@ hosted-git-info@^3.0.4, hosted-git-info@^3.0.5:
   integrity sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==
   dependencies:
     lru-cache "^6.0.0"
-
-hpack.js@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
-  integrity sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=
-  dependencies:
-    inherits "^2.0.1"
-    obuf "^1.0.0"
-    readable-stream "^2.0.1"
-    wbuf "^1.1.0"
 
 hsl-regex@^1.0.0:
   version "1.0.0"
@@ -9187,13 +9177,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  integrity sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
-  dependencies:
-    brace-expansion "^1.0.0"
-
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -9691,11 +9674,6 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-obuf@^1.0.0, obuf@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
-  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11220,7 +11198,7 @@ read@^1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -13653,13 +13631,6 @@ watchpack@^1.6.1:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
-
-wbuf@^1.1.0, wbuf@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
-  integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
-  dependencies:
-    minimalistic-assert "^1.0.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
-brace-expansion@^1.0.0, brace-expansion@^1.1.7:
+brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
@@ -4649,6 +4649,8 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
@@ -7380,16 +7382,6 @@ hosted-git-info@^3.0.4, hosted-git-info@^3.0.5:
   dependencies:
     lru-cache "^6.0.0"
 
-hpack.js@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
-  integrity sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=
-  dependencies:
-    inherits "^2.0.1"
-    obuf "^1.0.0"
-    readable-stream "^2.0.1"
-    wbuf "^1.1.0"
-
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -9187,13 +9179,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  integrity sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
-  dependencies:
-    brace-expansion "^1.0.0"
-
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -9691,11 +9676,6 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-obuf@^1.0.0, obuf@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
-  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11220,7 +11200,7 @@ read@^1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -11259,6 +11239,8 @@ recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
   integrity sha1-kO8jHQd4xc4JPJpI105cVCLROpk=
+  dependencies:
+    minimatch "3.0.3"
 
 redux-thunk@^2.3.0:
   version "2.3.0"
@@ -12364,6 +12346,13 @@ spdy-transport@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
   integrity sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==
+  dependencies:
+    debug "^4.1.0"
+    detect-node "^2.0.4"
+    hpack.js "^2.1.6"
+    obuf "^1.1.2"
+    readable-stream "^3.0.6"
+    wbuf "^1.7.3"
 
 spdy@^4.0.2:
   version "4.0.2"
@@ -13653,13 +13642,6 @@ watchpack@^1.6.1:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
-
-wbuf@^1.1.0, wbuf@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
-  integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
-  dependencies:
-    minimalistic-assert "^1.0.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4649,8 +4649,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
 
 debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
@@ -6422,10 +6420,10 @@ gatsby-interface@^0.0.166:
     lodash.sample "^4.2.1"
     theme-ui "^0.2.49"
 
-gatsby-interface@^0.0.193:
-  version "0.0.193"
-  resolved "https://registry.npmjs.org/gatsby-interface/-/gatsby-interface-0.0.193.tgz#132bb3edb847bfddbf66073279526afda7687490"
-  integrity sha512-4rSk8MLTtJXivKy2Znd6OgMBzEN7FRuhPd3/MZ99Te6ZG/3v0hHQ+GdtDu2fyMuaeznMSBDTfeipi7BO6mR9Eg==
+gatsby-interface@^0.0.194-Elanhant-minor-fixes-20200902T1627:
+  version "0.0.194-Elanhant-minor-fixes-20200902T1627"
+  resolved "https://registry.npmjs.org/gatsby-interface/-/gatsby-interface-0.0.194-Elanhant-minor-fixes-20200902T1627.tgz#1837bab68be768502c50d4c044d34c0ff622774b"
+  integrity sha512-u/COdT6lYYcxAMbOMEdf+91daDskZkjwMO/baHKlOgWrudrEwmrobdX6Q4yl8EE7s9RQAz35T+GewLRS41zTrg==
   dependencies:
     "@mdx-js/react" "^1.5.2"
     "@reach/alert" "0.10.3"
@@ -11261,8 +11259,6 @@ recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
   integrity sha1-kO8jHQd4xc4JPJpI105cVCLROpk=
-  dependencies:
-    minimatch "3.0.3"
 
 redux-thunk@^2.3.0:
   version "2.3.0"
@@ -12368,13 +12364,6 @@ spdy-transport@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
   integrity sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==
-  dependencies:
-    debug "^4.1.0"
-    detect-node "^2.0.4"
-    hpack.js "^2.1.6"
-    obuf "^1.1.2"
-    readable-stream "^3.0.6"
-    wbuf "^1.7.3"
 
 spdy@^4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,7 +3251,7 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
-brace-expansion@^1.1.7:
+brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
@@ -7382,6 +7382,16 @@ hosted-git-info@^3.0.4, hosted-git-info@^3.0.5:
   dependencies:
     lru-cache "^6.0.0"
 
+hpack.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
+  integrity sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=
+  dependencies:
+    inherits "^2.0.1"
+    obuf "^1.0.0"
+    readable-stream "^2.0.1"
+    wbuf "^1.1.0"
+
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -9179,6 +9189,13 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
+minimatch@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  integrity sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
+  dependencies:
+    brace-expansion "^1.0.0"
+
 minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -9676,6 +9693,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+obuf@^1.0.0, obuf@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -11200,7 +11222,7 @@ read@^1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -13642,6 +13664,13 @@ watchpack@^1.6.1:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+wbuf@^1.1.0, wbuf@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
+  integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
+  dependencies:
+    minimalistic-assert "^1.0.0"
 
 web-namespaces@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
"View logs" panel will now display two tabs — "Logs" (with structured logs) and "Raw Logs". The shape of `LogObject` is a bit different from what we use in Cloud, so we need to map these log items to properly display them (see `logObjectToBuildLogItem`).

Also completes all of the TODO items related to gatsby-interface issues and adjusts site card width a little bit.