### PR TITLE
Make site chooser a controlled form

### DIFF
--- a/src/components/onboarding/choose-sites.tsx
+++ b/src/components/onboarding/choose-sites.tsx
@@ -41,18 +41,7 @@ export function ChooseSites({
 
   const onSubmit: React.FocusEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault()
-    const siteCheckboxes = e.currentTarget.elements.namedItem(
-      `sitesToImport`
-    ) as RadioNodeList
-    // Because we use always use the auto-discovered list as the source of truth, rather than choosing sites,
-    // we actually hiden the unchecked sites
-    const hidden = []
-    for (const checkbox of siteCheckboxes) {
-      if (!(checkbox as HTMLInputElement).checked) {
-        hidden.push((checkbox as HTMLInputElement).value)
-      }
-    }
-    setHiddenSites(hidden)
+
     onGoNext()
   }
 
@@ -100,6 +89,7 @@ export function ChooseSites({
             sites={sites}
             hiddenSites={hiddenSites}
             browseSites={browseSites}
+            setHiddenSites={setHiddenSites}
           />
         )}
         {!noSites && (

--- a/src/components/onboarding/sites-checkbox-group.tsx
+++ b/src/components/onboarding/sites-checkbox-group.tsx
@@ -12,6 +12,7 @@ import { MdArrowForward } from "react-icons/md"
 import { visuallyHiddenCss } from "../../util/a11y"
 import { GroupInputCard, GroupButtonCard } from "./group-input-card"
 import { FolderName } from "../folder-name"
+import { ChangeEvent, useCallback } from "react"
 
 export interface IProps {
   name: string
@@ -19,6 +20,7 @@ export interface IProps {
   required?: boolean
   error?: React.ReactNode
   hiddenSites: Array<string>
+  setHiddenSites: (sites: Array<string>) => void
   browseSites: () => void
 }
 
@@ -28,6 +30,7 @@ export function SiteCheckboxGroup({
   required,
   error,
   hiddenSites = [],
+  setHiddenSites,
   browseSites,
 }: IProps): JSX.Element {
   const {
@@ -39,6 +42,18 @@ export function SiteCheckboxGroup({
     required: required,
     error,
   })
+
+  const toggleSites = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const hash = event.currentTarget.value
+      if (event.currentTarget.checked) {
+        setHiddenSites(hiddenSites.filter((site) => site !== hash))
+      } else {
+        setHiddenSites(Array.from(new Set([...hiddenSites, hash])))
+      }
+    },
+    [setHiddenSites, hiddenSites]
+  )
 
   return (
     <FormFieldset>
@@ -60,8 +75,9 @@ export function SiteCheckboxGroup({
                 <StyledCheckbox
                   {...getOptionControlProps(optionValue)}
                   value={optionValue}
-                  defaultChecked={!hidden}
+                  checked={!hiddenSites.includes(optionValue)}
                   name={name}
+                  onChange={toggleSites}
                 />
               }
               sx={{ pl: 7 }}


### PR DESCRIPTION
This changes the form for picking sites into a controlled form, rather than the existing implementation which iterates through the form elements on submit. That caused #28 