### PR TITLE
Empty state for not running site, informational modals

### DIFF
--- a/src/components/site-actions.tsx
+++ b/src/components/site-actions.tsx
@@ -1,0 +1,57 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import {
+  Text,
+  SplitButton,
+  DropdownMenuItem,
+  SplitButtonProps,
+} from "gatsby-interface"
+import { useCallback } from "react"
+import { GatsbySite, WorkerStatus, Status } from "../controllers/site"
+import { useSiteRunnerStatus } from "../util/site-runners"
+
+interface IProps
+  extends Omit<
+    SplitButtonProps,
+    "children" | "buttonLabel" | "dropdownButtonLabel"
+  > {
+  site: GatsbySite
+}
+
+export function SiteActions({ site, ...rest }: IProps): JSX.Element {
+  const { status, running, pid } = useSiteRunnerStatus(site)
+
+  const stop = useCallback(() => site?.stop(), [site])
+  const start = useCallback(() => site?.start(), [site])
+  const clean = useCallback(() => site?.start(true), [site])
+
+  return (
+    <SplitButton
+      size="S"
+      variant="SECONDARY"
+      textVariant="BRAND"
+      onClick={start}
+      buttonLabel={running ? `Restart` : `Start`}
+      dropdownButtonLabel="More site actions"
+      sx={{ fontFamily: `sans` }}
+      {...rest}
+    >
+      <DropdownMenuItem onSelect={clean}>
+        <Text sx={{ fontFamily: `sans`, fontSize: 1 }} as="span">
+          Clear Cache and {running ? `Restart` : `Start`}
+        </Text>
+      </DropdownMenuItem>
+      {canBeKilled(status, pid) && (
+        <DropdownMenuItem onSelect={stop}>
+          <Text sx={{ fontFamily: `sans`, fontSize: 1 }} as="span">
+            Stop
+          </Text>
+        </DropdownMenuItem>
+      )}
+    </SplitButton>
+  )
+}
+
+function canBeKilled(status: Status, pid?: number): boolean {
+  return status !== WorkerStatus.RunningInBackground || !!pid
+}

--- a/src/components/site-card/manage-in-desktop.tsx
+++ b/src/components/site-card/manage-in-desktop.tsx
@@ -1,0 +1,62 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import {
+  Modal,
+  ModalCard,
+  Button,
+  StyledModal,
+  StyledModalHeader,
+  StyledModalBody,
+  StyledModalActions,
+  Text,
+} from "gatsby-interface"
+import { Fragment, useState } from "react"
+import { GhostButton } from "./ghost-button"
+
+export function ManageInDesktop(): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const closeModal = (): void => {
+    setIsOpen(false)
+  }
+
+  return (
+    <Fragment>
+      <GhostButton onClick={(): void => setIsOpen(true)} size="S">
+        Manage this site in Gatsby Desktop
+      </GhostButton>
+      <Modal
+        aria-label="Manage this site in Gatsby Desktop"
+        isOpen={isOpen}
+        onDismiss={closeModal}
+      >
+        <ModalCard>
+          <StyledModal variant="ACTION">
+            <StyledModalHeader onCloseButtonClick={closeModal}>
+              Manage this site in Gatsby Desktop
+            </StyledModalHeader>
+            <StyledModalBody>
+              <Text sx={{ m: 0 }}>
+                This site was started by running gatsby develop in the terminal.
+                To manage it via Gatsby Desktop:
+              </Text>
+              <Text sx={{ mt: 5, mb: 0 }}>
+                <ul sx={{ m: 0, listStyleType: `decimal` }}>
+                  <li>
+                    Stop the develop process in the terminal and then start it
+                    from Gatsby Desktop, or
+                  </li>
+                  <li>Update the site to the latest Gatsby version.</li>
+                </ul>
+              </Text>
+              <StyledModalActions>
+                <div />
+                <Button onClick={closeModal}>Got it</Button>
+              </StyledModalActions>
+            </StyledModalBody>
+          </StyledModal>
+        </ModalCard>
+      </Modal>
+    </Fragment>
+  )
+}

--- a/src/components/site-card/setup-admin.tsx
+++ b/src/components/site-card/setup-admin.tsx
@@ -1,0 +1,58 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import {
+  Modal,
+  ModalCard,
+  Button,
+  StyledModal,
+  StyledModalHeader,
+  StyledModalBody,
+  StyledModalActions,
+  Text,
+} from "gatsby-interface"
+import { Fragment, useState } from "react"
+import { GhostButton } from "./ghost-button"
+
+export function SetupAdmin(): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const closeModal = (): void => {
+    setIsOpen(false)
+  }
+
+  return (
+    <Fragment>
+      <GhostButton onClick={(): void => setIsOpen(true)} size="S">
+        Use Gatsby Admin with this site
+      </GhostButton>
+      <Modal
+        aria-label="Use Gatsby Admin with this site"
+        isOpen={isOpen}
+        onDismiss={closeModal}
+      >
+        <ModalCard>
+          <StyledModal variant="ACTION">
+            <StyledModalHeader onCloseButtonClick={closeModal}>
+              Use Gatsby Admin with this site
+            </StyledModalHeader>
+            <StyledModalBody>
+              <Text sx={{ m: 0 }}>
+                Please update to the latest Gatsby version in order to use
+                Gatsby&nbsp;Admin for this site.
+              </Text>
+              <Text sx={{ mt: 5, mb: 0 }}>
+                Your Gatsby version: <strong>TODO</strong>
+                <br />
+                Latest Gatsby version: <strong>TODO</strong>
+              </Text>
+              <StyledModalActions>
+                <div />
+                <Button onClick={closeModal}>Got it</Button>
+              </StyledModalActions>
+            </StyledModalBody>
+          </StyledModal>
+        </ModalCard>
+      </Modal>
+    </Fragment>
+  )
+}

--- a/src/pages/sites/[hash].tsx
+++ b/src/pages/sites/[hash].tsx
@@ -1,8 +1,10 @@
 /** @jsx jsx */
 import { jsx, Flex } from "theme-ui"
-import { Text } from "gatsby-interface"
+import { Text, EmptyState } from "gatsby-interface"
 import { useSiteRunnerStatus, useSiteForHash } from "../../util/site-runners"
 import { Layout } from "../../components/layout"
+import { SiteActions } from "../../components/site-actions"
+import { GatsbySite } from "../../controllers/site"
 
 export interface IProps {
   params: {
@@ -13,33 +15,49 @@ export interface IProps {
 export default function SitePage({ params }: IProps): JSX.Element {
   const site = useSiteForHash(params.hash)
 
-  if (!site) {
-    return (
-      <Layout>
-        <main>
-          <Text>Not found</Text>
-        </main>
-      </Layout>
-    )
-  }
+  return (
+    <Layout>
+      <main sx={{ height: `100%` }}>
+        {site ? <SiteDetails site={site} /> : <Text>Not found</Text>}
+      </main>
+    </Layout>
+  )
+}
+
+function SiteDetails({ site }: { site: GatsbySite }): JSX.Element {
   const { running, port } = useSiteRunnerStatus(site)
 
   return (
-    <Layout>
-      <Flex>
-        {running && port ? (
-          <iframe
-            frameBorder={0}
-            src={`http://localhost:${port}/___admin/`}
-            sx={{
-              flex: 1,
-            }}
-            onError={(): void => console.error(`iframe error`)}
-          />
-        ) : (
-          <Text>Not running</Text>
-        )}
-      </Flex>
-    </Layout>
+    <Flex sx={{ height: `100%` }}>
+      {running && port ? (
+        <iframe
+          frameBorder={0}
+          src={`http://localhost:${port}/___admin/`}
+          sx={{
+            flex: 1,
+          }}
+          onError={(): void => console.error(`iframe error`)}
+        />
+      ) : (
+        <Flex
+          sx={{
+            alignItems: `center`,
+            justifyContent: `center`,
+            width: `100%`,
+            height: `100%`,
+          }}
+        >
+          <div sx={{ maxWidth: `20rem` }}>
+            <EmptyState
+              heading="This site is not running"
+              text={`Please start the gatsby develop process in order to use Gatsby \u000A Admin for this site.`}
+              primaryAction={
+                <SiteActions site={site} variant="PRIMARY" size="M" />
+              }
+            />
+          </div>
+        </Flex>
+      )}
+    </Flex>
   )
 }


### PR DESCRIPTION
Adds informational modals to indicate if a site has been started via CLI or if it does not support Gatsby Admin:

<img width="687" alt="Screen Shot 2020-09-04 at 12 55 12 PM" src="https://user-images.githubusercontent.com/4366711/92280256-dfd12500-eead-11ea-98b3-2dff751c932f.png">
<img width="655" alt="Screen Shot 2020-09-04 at 12 55 32 PM" src="https://user-images.githubusercontent.com/4366711/92280280-ebbce700-eead-11ea-97b9-2003d66c0625.png">

----

Also adds a "Site is not running" empty state to site view: <img width="1326" alt="Screen Shot 2020-09-04 at 12 54 18 PM" src="https://user-images.githubusercontent.com/4366711/92280187-c039fc80-eead-11ea-9fff-2ba979b82fd3.png">
