### PR TITLE
Keep tray in scope

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -48,6 +48,8 @@ function makeWindow(): BrowserWindow {
   })
 }
 
+let tray: Tray
+
 async function start(): Promise<void> {
   fixPath()
   /**
@@ -200,7 +202,7 @@ async function start(): Promise<void> {
 
   mainWindow = makeWindow()
 
-  const tray = new Tray(path.resolve(dir, `assets`, `IconTemplate.png`))
+  tray = new Tray(path.resolve(dir, `assets`, `IconTemplate.png`))
   const contextMenu = Menu.buildFromTemplate([
     {
       label: `Show Gatsby Desktop`,


### PR DESCRIPTION
Moves the Tray out of the handler scope to the top module level. This is because it was getting GCd, meaning the menubar was disappearing.

https://www.electronjs.org/docs/faq#my-apps-tray-disappeared-after-a-few-minutes