### PR TITLE
Add telemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Gatsby Desktop is written in TypeScript. We use [microbundle](https://github.com
 
 To debug the renderer, use [Chrome devtools](chrome://inspect/#devices) and listen to port 8315.
 
+## Telemetry
+
+If you opt-in to telemetry, the app sends anonymous information about how use it. This is mainly checking which features you use and how much you use them. This helps us prioritize which features to develop, and to improve the app. This is particularly important as it is a proof-of-concept. This is entirely optional though, so if you don't opt-in we don't track anything except the fact that you have opted-out. All other events are not sent. This setting is separate from the telemetry setting for Gatsby itself. You can see more details on telemetry in Gatsby at https://gatsby.dev/telemetry
+
 ### Release process
 
 Create a draft release in GitHub, with the tag as the new version number prefixed with `v`, e.g. `v0.0.1-alpha.2`. Update the version number in package.json to match, and commit. Push that to master and GitHub Actions should do a build and eventually attach the packaged files to the draft release. Once the build is complete, publish the draft release.

--- a/app/main.ts
+++ b/app/main.ts
@@ -22,7 +22,7 @@ import {
 import { watchSites, stopWatching, ISiteMetadata } from "./site-watcher"
 import { SiteLauncher, Message } from "./launcher"
 import { Status, LogObject, SiteError } from "./ipc-types"
-import { initializeTelemetry } from "./telemetry"
+import { initializeTelemetry, trackEvent } from "./telemetry"
 interface ISiteStatus {
   startedInDesktop?: boolean
   status: Status
@@ -160,6 +160,7 @@ async function start(): Promise<void> {
       event.preventDefault()
       return
     }
+    trackEvent(`GATSBY_DESKTOP_QUIT`)
     siteLaunchers.forEach((site) => site.stop())
     stopWatching()
   })

--- a/app/main.ts
+++ b/app/main.ts
@@ -22,6 +22,7 @@ import {
 import { watchSites, stopWatching, ISiteMetadata } from "./site-watcher"
 import { SiteLauncher, Message } from "./launcher"
 import { Status, LogObject, SiteError } from "./ipc-types"
+import { initializeTelemetry } from "./telemetry"
 interface ISiteStatus {
   startedInDesktop?: boolean
   status: Status
@@ -197,6 +198,8 @@ async function start(): Promise<void> {
   // Wait til the app is ready
 
   await app.whenReady()
+
+  initializeTelemetry()
 
   mainWindow = makeWindow()
 

--- a/app/telemetry.ts
+++ b/app/telemetry.ts
@@ -7,10 +7,19 @@ import {
 } from "gatsby-telemetry"
 import { app, ipcMain, IpcMainEvent } from "electron"
 import { ITelemetryTagsPayload } from "gatsby-telemetry/lib/telemetry"
+import Store from "electron-store"
+
+interface IConfigType {
+  telemetryOptIn: boolean
+}
+
+let telemetryEnabled = true
 
 function telemetryTrackFeatureIsUsed(event: IpcMainEvent, name: string): void {
-  console.log(`track feature is used`, name)
-  trackFeatureIsUsed(name)
+  console.log(`track feature is used`, name, { telemetryEnabled })
+  if (telemetryEnabled) {
+    trackFeatureIsUsed(name)
+  }
 }
 
 function trackEvent(
@@ -18,14 +27,24 @@ function trackEvent(
   input: string | Array<string>,
   tags?: ITelemetryTagsPayload
 ): void {
-  console.log(`track event`, input, tags)
-  trackCli(input, tags)
+  console.log(`track event`, input, tags, { telemetryEnabled })
+  if (telemetryEnabled) {
+    trackCli(input, tags)
+  }
 }
 
 export function initializeTelemetry(): void {
   setDefaultComponentId(`gatsby-desktop`)
   setGatsbyCliVersion(app.getVersion())
   startBackgroundUpdate()
+  const store = new Store<IConfigType>()
+  store.onDidChange(`telemetryOptIn`, (newValue?: boolean) => {
+    telemetryEnabled = !!newValue
+  })
+  if (store.get(`telemetryOptIn`) === false) {
+    console.log(`running with telemetry disabled`)
+    trackCli(`RUNNING_WITH_TELEMETRY_DISABLED`)
+  }
   ipcMain.on(`telemetry-trackFeatureIsUsed`, telemetryTrackFeatureIsUsed)
   ipcMain.on(`telemetry-trackEvent`, trackEvent)
 }

--- a/app/telemetry.ts
+++ b/app/telemetry.ts
@@ -1,10 +1,16 @@
-import telemetry from "gatsby-telemetry"
+import {
+  startBackgroundUpdate,
+  trackCli,
+  setDefaultComponentId,
+  setGatsbyCliVersion,
+  trackFeatureIsUsed,
+} from "gatsby-telemetry"
 import { app, ipcMain, IpcMainEvent } from "electron"
 import { ITelemetryTagsPayload } from "gatsby-telemetry/lib/telemetry"
 
-function trackFeatureIsUsed(event: IpcMainEvent, name: string): void {
+function telemetryTrackFeatureIsUsed(event: IpcMainEvent, name: string): void {
   console.log(`track feature is used`, name)
-  telemetry.trackFeatureIsUsed(name)
+  trackFeatureIsUsed(name)
 }
 
 function trackEvent(
@@ -13,12 +19,13 @@ function trackEvent(
   tags?: ITelemetryTagsPayload
 ): void {
   console.log(`track event`, input, tags)
-  telemetry.trackCli(input, tags)
+  trackCli(input, tags)
 }
 
 export function initializeTelemetry(): void {
-  telemetry.setDefaultComponentId(`gatsby-desktop`)
-  telemetry.setGatsbyCliVersion(app.getVersion())
-  ipcMain.on(`telemetry-trackFeatureIsUsed`, trackFeatureIsUsed)
+  setDefaultComponentId(`gatsby-desktop`)
+  setGatsbyCliVersion(app.getVersion())
+  startBackgroundUpdate()
+  ipcMain.on(`telemetry-trackFeatureIsUsed`, telemetryTrackFeatureIsUsed)
   ipcMain.on(`telemetry-trackEvent`, trackEvent)
 }

--- a/app/telemetry.ts
+++ b/app/telemetry.ts
@@ -1,7 +1,24 @@
 import telemetry from "gatsby-telemetry"
-import { app } from "electron"
+import { app, ipcMain, IpcMainEvent } from "electron"
+import { ITelemetryTagsPayload } from "gatsby-telemetry/lib/telemetry"
 
-export function startListening(): void {
+function trackFeatureIsUsed(event: IpcMainEvent, name: string): void {
+  console.log(`track feature is used`, name)
+  telemetry.trackFeatureIsUsed(name)
+}
+
+function trackEvent(
+  event: IpcMainEvent,
+  input: string | Array<string>,
+  tags?: ITelemetryTagsPayload
+): void {
+  console.log(`track event`, input, tags)
+  telemetry.trackCli(input, tags)
+}
+
+export function initializeTelemetry(): void {
   telemetry.setDefaultComponentId(`gatsby-desktop`)
   telemetry.setGatsbyCliVersion(app.getVersion())
+  ipcMain.on(`telemetry-trackFeatureIsUsed`, trackFeatureIsUsed)
+  ipcMain.on(`telemetry-trackEvent`, trackEvent)
 }

--- a/app/telemetry.ts
+++ b/app/telemetry.ts
@@ -1,0 +1,7 @@
+import telemetry from "gatsby-telemetry"
+import { app } from "electron"
+
+export function startListening(): void {
+  telemetry.setDefaultComponentId(`gatsby-desktop`)
+  telemetry.setGatsbyCliVersion(app.getVersion())
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gatsby": "^2.24.47",
     "gatsby-design-tokens": "^2.0.10",
     "gatsby-interface": "^0.0.196",
-    "gatsby-telemetry": "^1.3.31",
+    "gatsby-telemetry": "^1.3.36",
     "open-in-editor": "^2.2.0",
     "promisify-child-process": "^4.1.1",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gatsby": "^2.24.47",
     "gatsby-design-tokens": "^2.0.10",
     "gatsby-interface": "^0.0.196",
+    "gatsby-telemetry": "^1.3.31",
     "open-in-editor": "^2.2.0",
     "promisify-child-process": "^4.1.1",
     "react": "^16.13.1",

--- a/src/components/onboarding/choose-editor.tsx
+++ b/src/components/onboarding/choose-editor.tsx
@@ -11,6 +11,7 @@ import {
 import { EditorsRadioButton } from "./editors-radio-button"
 import { ALL_EDITORS, CodeEditor } from "../../util/editors"
 import { useConfig } from "../../util/use-config"
+import { trackEvent } from "../../util/telemetry"
 
 export interface IProps
   extends Pick<WizardStepProps, "currentStep" | "totalSteps"> {
@@ -28,9 +29,10 @@ export function ChooseEditor({
   const onSubmit: React.FocusEventHandler<HTMLFormElement> = useCallback(
     (e) => {
       e.preventDefault()
+      trackEvent(`SET_EDITOR`, { name: preferredEditor })
       onGoNext()
     },
-    [onGoNext]
+    [onGoNext, preferredEditor]
   )
 
   console.log({ preferredEditor })

--- a/src/components/onboarding/choose-sites.tsx
+++ b/src/components/onboarding/choose-sites.tsx
@@ -12,6 +12,7 @@ import {
 } from "./onboarding-wizard-step"
 import { useSiteBrowser } from "../site-browser"
 import { ISiteInfo } from "../../controllers/site"
+import { trackEvent } from "../../util/telemetry"
 
 export interface IProps
   extends Pick<WizardStepProps, "currentStep" | "totalSteps"> {
@@ -41,6 +42,11 @@ export function ChooseSites({
 
   const onSubmit: React.FocusEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault()
+
+    sites.forEach((site) => trackEvent(`SITE_ADDED`, { siteHash: site.hash }))
+    hiddenSites.forEach((hash) =>
+      trackEvent(`SITE_DESELECTED`, { siteHash: hash })
+    )
 
     onGoNext()
   }

--- a/src/components/onboarding/intro.tsx
+++ b/src/components/onboarding/intro.tsx
@@ -64,7 +64,7 @@ export function OnboardingIntro({ onGoNext }: IProps): JSX.Element {
         <CheckboxFieldBlock
           id="anonUsage"
           name="anonUsage"
-          label="Yes, submit anonymous usage information"
+          label="Yes, help improve Gatsby Desktop"
           onChange={onToggle}
           checked={optedIn}
         />

--- a/src/components/site-browser.tsx
+++ b/src/components/site-browser.tsx
@@ -11,6 +11,7 @@ import {
   StyledModalBody,
   StyledModalActions,
 } from "gatsby-interface"
+import { trackEvent } from "../util/telemetry"
 
 export function useSiteBrowser(
   onSelectSite?: (siteInfo: ISiteInfo) => void,
@@ -21,6 +22,7 @@ export function useSiteBrowser(
   const closeErrorModal = (): void => setSiteError(null)
 
   const browse = useCallback(async () => {
+    trackEvent(`CLICK_ADD_SITE`)
     console.log(`browsing`)
     // Sends a message to the main process asking for a file dialog.
     // It also verifies that it's a Gatsby site before returning it.

--- a/src/components/site-card/editor-launcher.tsx
+++ b/src/components/site-card/editor-launcher.tsx
@@ -4,20 +4,27 @@ import { IconButton, Tooltip } from "gatsby-interface"
 import { useCallback, useMemo } from "react"
 import openInEditor from "open-in-editor"
 import { editorIcons, CodeEditor, editorLabels } from "../../util/editors"
+import { trackEvent } from "../../util/telemetry"
 
 export interface IProps {
   path: string
   editor?: CodeEditor
+  siteHash?: string
 }
 
-export function EditorLauncher({ path, editor = `code` }: IProps): JSX.Element {
+export function EditorLauncher({
+  path,
+  editor = `code`,
+  siteHash,
+}: IProps): JSX.Element {
   const editorInstance = useMemo(() => openInEditor.configure({ editor }), [
     editor,
   ])
 
   const openEditor = useCallback((): void => {
+    trackEvent(`LAUNCH_EDITOR`, { name: editor, siteHash })
     editorInstance.open(path)
-  }, [editorInstance])
+  }, [editorInstance, siteHash])
   return (
     <Tooltip
       label={`Open in ${editorLabels[editor]}`}

--- a/src/components/site-card/editor-launcher.tsx
+++ b/src/components/site-card/editor-launcher.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { IconButton, Tooltip } from "gatsby-interface"
-import { useMemo } from "react"
+import { useMemo, useCallback } from "react"
 import openInEditor from "open-in-editor"
 import { editorIcons, CodeEditor, editorLabels } from "../../util/editors"
 import { trackEvent } from "../../util/telemetry"
@@ -21,10 +21,10 @@ export function EditorLauncher({
     editor,
   ])
 
-  const openEditor = (): void => {
+  const openEditor = useCallback((): void => {
     trackEvent(`LAUNCH_EDITOR`, { name: editor, siteHash })
     editorInstance.open(path)
-  }
+  }, [editor, siteHash, editorInstance])
 
   return (
     <Tooltip

--- a/src/components/site-card/editor-launcher.tsx
+++ b/src/components/site-card/editor-launcher.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { IconButton, Tooltip } from "gatsby-interface"
-import { useCallback, useMemo } from "react"
+import { useMemo } from "react"
 import openInEditor from "open-in-editor"
 import { editorIcons, CodeEditor, editorLabels } from "../../util/editors"
 import { trackEvent } from "../../util/telemetry"
@@ -21,10 +21,11 @@ export function EditorLauncher({
     editor,
   ])
 
-  const openEditor = useCallback((): void => {
+  const openEditor = (): void => {
     trackEvent(`LAUNCH_EDITOR`, { name: editor, siteHash })
     editorInstance.open(path)
-  }, [editorInstance, siteHash])
+  }
+
   return (
     <Tooltip
       label={`Open in ${editorLabels[editor]}`}

--- a/src/components/site-card/logs-launcher.tsx
+++ b/src/components/site-card/logs-launcher.tsx
@@ -8,12 +8,14 @@ import { isErrored } from "../../util/site-status"
 import { GhostButton } from "./ghost-button"
 import { SiteStatusDot } from "../site-status-dot"
 import { LogObject } from "../../util/ipc-types"
+import { trackEvent } from "../../util/telemetry"
 
 export interface IProps {
   structuredLogs: Array<LogObject>
   logs: Array<string>
   status: Status
   siteName: string
+  siteHash?: string
 }
 
 export function LogsLauncher({
@@ -21,12 +23,18 @@ export function LogsLauncher({
   logs,
   status,
   siteName,
+  siteHash,
 }: IProps): JSX.Element {
   const error = isErrored(status)
   const [isOpen, setIsOpen] = useState(false)
   const toggleLogs = useCallback((): void => {
-    setIsOpen((open) => !open)
-  }, [setIsOpen])
+    setIsOpen((open) => {
+      if (!open) {
+        trackEvent(`OPEN_LOGS`, { siteHash })
+      }
+      return !open
+    })
+  }, [setIsOpen, siteHash])
   return (
     <Fragment>
       <GhostButton onClick={toggleLogs} size="S">

--- a/src/components/site-card/manage-in-desktop.tsx
+++ b/src/components/site-card/manage-in-desktop.tsx
@@ -12,6 +12,7 @@ import {
 } from "gatsby-interface"
 import { Fragment, useState } from "react"
 import { GhostButton } from "./ghost-button"
+import { trackEvent } from "../../util/telemetry"
 
 export function ManageInDesktop(): JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
@@ -20,9 +21,14 @@ export function ManageInDesktop(): JSX.Element {
     setIsOpen(false)
   }
 
+  const openModal = (): void => {
+    setIsOpen(true)
+    trackEvent(`SHOW_MANAGE_SITE_HELP`)
+  }
+
   return (
     <Fragment>
-      <GhostButton onClick={(): void => setIsOpen(true)} size="S">
+      <GhostButton onClick={openModal} size="S">
         Manage this site in Gatsby Desktop
       </GhostButton>
       <Modal

--- a/src/components/site-card/site-card.tsx
+++ b/src/components/site-card/site-card.tsx
@@ -21,6 +21,7 @@ import { useConfig } from "../../util/use-config"
 import { ManageInDesktop } from "./manage-in-desktop"
 import { SiteActions } from "../site-actions"
 import { SetupAdmin } from "./setup-admin"
+import { trackEvent } from "../../util/telemetry"
 
 interface IProps {
   site: GatsbySite
@@ -86,7 +87,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
                 </span>
                 <div sx={{ mr: 3 }}>
                   {displayStatus === SiteDisplayStatus.Running && !!port ? (
-                    <SiteLauncher port={port} />
+                    <SiteLauncher port={port} siteHash={site.hash} />
                   ) : displayStatus === SiteDisplayStatus.Starting ? (
                     <Text as="span" sx={{ fontSize: 0, color: `grey.60` }}>
                       Starting site...
@@ -99,6 +100,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
                     logs={rawLogs}
                     status={status}
                     siteName={site.name}
+                    siteHash={site.hash}
                   />
                 )}
               </Fragment>
@@ -107,7 +109,11 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
           </Flex>
         </Flex>
         <Flex mt="auto">
-          <EditorLauncher path={site.root} editor={editor} />
+          <EditorLauncher
+            path={site.root}
+            editor={editor}
+            siteHash={site.hash}
+          />
         </Flex>
       </Flex>
       <button
@@ -126,6 +132,7 @@ export function SiteCard({ site }: PropsWithChildren<IProps>): JSX.Element {
         aria-label="Open site admin"
         onClick={(event): void => {
           event.stopPropagation()
+          trackEvent(`CLICK_TO_OPEN_ADMIN_TAB`, { siteHash: site.hash })
           addTab(site.hash)
           navigate(`/sites/${site.hash}`)
         }}

--- a/src/components/site-card/site-launcher.tsx
+++ b/src/components/site-card/site-launcher.tsx
@@ -3,15 +3,18 @@ import { jsx } from "theme-ui"
 import { shell } from "electron"
 import { useCallback } from "react"
 import { GhostButton } from "./ghost-button"
+import { trackEvent } from "../../util/telemetry"
 
 export interface IProps {
   port: number
+  siteHash?: string
 }
 
-export function SiteLauncher({ port }: IProps): JSX.Element {
+export function SiteLauncher({ port, siteHash }: IProps): JSX.Element {
   const openUrl = useCallback((): void => {
+    trackEvent(`CLICK_TO_OPEN_SITE_IN_BROWSER`, { siteHash })
     shell.openExternal(`http://localhost:${port}`)
-  }, [])
+  }, [port, siteHash])
   return (
     <GhostButton onClick={openUrl} size="S">
       localhost:{port}

--- a/src/components/tab-navigation.tsx
+++ b/src/components/tab-navigation.tsx
@@ -9,7 +9,8 @@ import { useLocation } from "@reach/router"
 import { MdClear } from "react-icons/md"
 import { SiteStatusDot } from "./site-status-dot"
 
-interface ITabProps extends Omit<GatsbyLinkProps<unknown>, "to" | "ref"> {
+interface ITabProps
+  extends Omit<GatsbyLinkProps<unknown>, "to" | "ref" | "sx"> {
   site: GatsbySite
 }
 

--- a/src/components/tab-navigation.tsx
+++ b/src/components/tab-navigation.tsx
@@ -101,7 +101,6 @@ export function SiteTabLink({ site, ...props }: ITabProps): JSX.Element {
 
 export function TabNavigation(): JSX.Element {
   const { siteTabs } = useSiteTabs()
-  console.log(`tab nav`)
   return (
     <Flex
       as="nav"

--- a/src/controllers/site.ts
+++ b/src/controllers/site.ts
@@ -15,6 +15,7 @@ import {
 import { createContentDigest } from "gatsby-core-utils"
 
 import { ipcRenderer } from "electron"
+import { trackEvent } from "../util/telemetry"
 
 // TODO: move these to gatsby-core-utils
 
@@ -144,6 +145,10 @@ export class GatsbySite {
     })
 
     ipcRenderer.send(`launch-site`, { root: this.root, hash: this.hash, clean })
+    trackEvent(clean ? `SITE_CLEAR_CACHE_AND_START` : `SITE_START`, {
+      siteHash: this.hash,
+      pathname: document?.location.pathname,
+    })
   }
 
   public updateStatus(newStatus: Partial<ISiteStatus>): void {
@@ -224,6 +229,10 @@ export class GatsbySite {
   public stop(): void {
     ipcRenderer.send(`stop-site`, { hash: this.hash, pid: this.siteStatus.pid })
     this.updateStatus({ status: WorkerStatus.Stopped, running: false })
+    trackEvent(`SITE_STOP`, {
+      siteHash: this.hash,
+      pathname: document?.location.pathname,
+    })
   }
 
   logMessage(message: string): void {

--- a/src/pages/onboarding/intro.tsx
+++ b/src/pages/onboarding/intro.tsx
@@ -4,6 +4,7 @@ import { navigate } from "gatsby"
 import { Layout } from "../../components/layout"
 import { OnboardingLayout } from "../../components/onboarding/onboarding-layout"
 import { OnboardingIntro } from "../../components/onboarding/intro"
+import { trackEvent } from "../../util/telemetry"
 
 export default function OnboardingIntroPage(): JSX.Element {
   return (
@@ -11,6 +12,7 @@ export default function OnboardingIntroPage(): JSX.Element {
       <OnboardingLayout withIllustration={true}>
         <OnboardingIntro
           onGoNext={(): void => {
+            trackEvent(`onboarding-next`)
             navigate(`/onboarding/editor`)
           }}
         />

--- a/src/pages/sites/index.tsx
+++ b/src/pages/sites/index.tsx
@@ -6,6 +6,7 @@ import { Heading, Text, LinkButton } from "gatsby-interface"
 import { MdArrowForward } from "react-icons/md"
 import { Layout } from "../../components/layout"
 import { useConfig } from "../../util/use-config"
+import { trackEvent } from "../../util/telemetry"
 
 export default function MainPage(): JSX.Element {
   const { filteredSites } = useSiteRunners()
@@ -36,6 +37,7 @@ export default function MainPage(): JSX.Element {
           </Text>
           <LinkButton
             to="/onboarding/intro"
+            onClick={(): void => trackEvent(`CLICK_TO_RERUN_ONBOARDING`)}
             // Easter egg: right click to clear config
             onContextMenu={(): void => store?.clear()}
             size="S"

--- a/src/util/telemetry.ts
+++ b/src/util/telemetry.ts
@@ -1,0 +1,13 @@
+import { ITelemetryTagsPayload } from "gatsby-telemetry/lib/telemetry"
+import { ipcRenderer } from "electron"
+
+export function trackFeatureIsUsed(name: string): void {
+  ipcRenderer.send(`telemetry-trackFeatureIsUsed`, name)
+}
+
+export function trackEvent(
+  input: string | Array<string>,
+  tags?: ITelemetryTagsPayload
+): void {
+  ipcRenderer.send(`telemetry-trackEvent`, input, tags)
+}

--- a/src/util/telemetry.ts
+++ b/src/util/telemetry.ts
@@ -7,7 +7,7 @@ export function trackFeatureIsUsed(name: string): void {
 
 export function trackEvent(
   input: string | Array<string>,
-  tags?: ITelemetryTagsPayload
+  tags?: ITelemetryTagsPayload & { siteHash?: string }
 ): void {
   ipcRenderer.send(`telemetry-trackEvent`, input, tags)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,6 +1754,13 @@
   dependencies:
     "@types/node-fetch" "2"
 
+"@turist/fetch@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@turist/fetch/-/fetch-7.1.7.tgz#a2b1f7ec0265e6fe0946c51eef34bad9b9efc865"
+  integrity sha512-XP20kvfyMNlWdPVQXyuzA40LoCHbbJptikt7W+TlZ5sS+NNjk70xjXCtHBLEudp7li3JldXEFSIUzpW1a0WEhA==
+  dependencies:
+    "@types/node-fetch" "2"
+
 "@turist/time@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@turist/time/-/time-0.0.1.tgz#57637d2a7d1860adb9f9cecbdcc966ce4f551d63"
@@ -5267,6 +5274,11 @@ envinfo@^7.5.1:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.2.tgz#098f97a0e902f8141f9150553c92dbb282c4cabe"
   integrity sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==
 
+envinfo@^7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.3.tgz#4b2d8622e3e7366afb8091b23ed95569ea0208cc"
+  integrity sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==
+
 eol@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
@@ -6388,6 +6400,19 @@ gatsby-core-utils@^1.3.15:
     proper-lockfile "^4.1.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^1.3.18:
+  version "1.3.18"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.18.tgz#8eecb424f8709bbb3dac9653973068643b3fd66f"
+  integrity sha512-B7ixQb4H0e2yB0nNfM2zshOAUw3nW9MvcNsRskVFwIPJY+ngh8Srla4XWXVMJ60Fyt103+jPVZTxGq72/u5HuQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-design-tokens@^2.0.10, gatsby-design-tokens@^2.0.2:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/gatsby-design-tokens/-/gatsby-design-tokens-2.0.10.tgz#cade197f538f93196b4e2253e48f09b9cac6cf68"
@@ -6615,6 +6640,27 @@ gatsby-telemetry@^1.3.27:
     node-fetch "2.6.0"
     uuid "3.4.0"
 
+gatsby-telemetry@^1.3.30:
+  version "1.3.30"
+  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.30.tgz#dd169f8674017597907cad2ce95127af7a4d7465"
+  integrity sha512-2EJdu8f7CqLfENnShK1gSJdlxC/me6eImrbReYQDuf7Bu7l9UT5Ag07D1vC8qA58wjj+p9mhZqAL5pYCdQ04jA==
+  dependencies:
+    "@babel/code-frame" "^7.10.3"
+    "@babel/runtime" "^7.10.3"
+    "@turist/fetch" "^7.1.7"
+    "@turist/time" "^0.0.1"
+    async-retry-ng "^2.0.1"
+    boxen "^4.2.0"
+    configstore "^5.0.1"
+    envinfo "^7.7.3"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.3.18"
+    git-up "^4.0.2"
+    is-docker "^2.1.1"
+    lodash "^4.17.15"
+    node-fetch "^2.6.0"
+    uuid "^8.3.0"
+
 gatsby@^2.24.47:
   version "2.24.47"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.24.47.tgz#44f50af6304111c0e5b7f9e9b777103dc2245a93"
@@ -6836,6 +6882,14 @@ git-up@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
   integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^5.0.0"
+
+git-up@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.2.tgz#10c3d731051b366dc19d3df454bfca3f77913a7c"
+  integrity sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==
   dependencies:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
@@ -7976,6 +8030,11 @@ is-docker@2.0.0, is-docker@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
   integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
+
+is-docker@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -13568,7 +13627,7 @@ uuid@3.4.0, uuid@^3.0.0, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.2.0:
+uuid@^8.2.0, uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6647,7 +6647,7 @@ gatsby-telemetry@^1.3.27:
     node-fetch "2.6.0"
     uuid "3.4.0"
 
-gatsby-telemetry@^1.3.31:
+gatsby-telemetry@^1.3.36:
   version "1.3.36"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.36.tgz#992cbb57ed019c4320093e4ee8ad26fe97152155"
   integrity sha512-a1g6WJ86BzOsnr4jemHgNSlpK7annC17m9sQ31iPQNLciowwfULbEKvrKCRYk1ABRUb1VNg61z6dzAnktF9giA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,6 +1003,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.5":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.0.tgz#f10245877042a815e07f7e693faff0ae9d3a2aac"
@@ -6400,10 +6407,10 @@ gatsby-core-utils@^1.3.15:
     proper-lockfile "^4.1.1"
     xdg-basedir "^4.0.0"
 
-gatsby-core-utils@^1.3.18:
-  version "1.3.18"
-  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.18.tgz#8eecb424f8709bbb3dac9653973068643b3fd66f"
-  integrity sha512-B7ixQb4H0e2yB0nNfM2zshOAUw3nW9MvcNsRskVFwIPJY+ngh8Srla4XWXVMJ60Fyt103+jPVZTxGq72/u5HuQ==
+gatsby-core-utils@^1.3.21:
+  version "1.3.21"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.21.tgz#fa988d04683527b1713c41df10c081712994781c"
+  integrity sha512-oaHdrfnip0u1pMVkO5O+R6YxJ6XBi662YCAPVj4G6DCQG9ngJOKNdaHXU1G9Mjalq6Kb/rNWNRMjOU5u78BdKQ==
   dependencies:
     ci-info "2.0.0"
     configstore "^5.0.1"
@@ -6640,13 +6647,13 @@ gatsby-telemetry@^1.3.27:
     node-fetch "2.6.0"
     uuid "3.4.0"
 
-gatsby-telemetry@^1.3.30:
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.30.tgz#dd169f8674017597907cad2ce95127af7a4d7465"
-  integrity sha512-2EJdu8f7CqLfENnShK1gSJdlxC/me6eImrbReYQDuf7Bu7l9UT5Ag07D1vC8qA58wjj+p9mhZqAL5pYCdQ04jA==
+gatsby-telemetry@^1.3.31:
+  version "1.3.36"
+  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.3.36.tgz#992cbb57ed019c4320093e4ee8ad26fe97152155"
+  integrity sha512-a1g6WJ86BzOsnr4jemHgNSlpK7annC17m9sQ31iPQNLciowwfULbEKvrKCRYk1ABRUb1VNg61z6dzAnktF9giA==
   dependencies:
-    "@babel/code-frame" "^7.10.3"
-    "@babel/runtime" "^7.10.3"
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.11.2"
     "@turist/fetch" "^7.1.7"
     "@turist/time" "^0.0.1"
     async-retry-ng "^2.0.1"
@@ -6654,12 +6661,12 @@ gatsby-telemetry@^1.3.30:
     configstore "^5.0.1"
     envinfo "^7.7.3"
     fs-extra "^8.1.0"
-    gatsby-core-utils "^1.3.18"
+    gatsby-core-utils "^1.3.21"
     git-up "^4.0.2"
     is-docker "^2.1.1"
-    lodash "^4.17.15"
+    lodash "^4.17.20"
     node-fetch "^2.6.0"
-    uuid "^8.3.0"
+    uuid "3.4.0"
 
 gatsby@^2.24.47:
   version "2.24.47"
@@ -8808,6 +8815,11 @@ lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-update@^3.0.0:
   version "3.4.0"
@@ -13627,7 +13639,7 @@ uuid@3.4.0, uuid@^3.0.0, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.2.0, uuid@^8.3.0:
+uuid@^8.2.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==


### PR DESCRIPTION
This adds support for gatsby-telemetry, by starting it in the main process and communicating with that from the renderer over IPC. It respects the opt-in setting from on-boarding. Currently there is just one event included. We'll wait until we've chosen what we need to track before merging this.

[ch16009]