### PR TITLE
feat: Check if site supports admin

### DIFF
--- a/src/controllers/site.ts
+++ b/src/controllers/site.ts
@@ -22,6 +22,7 @@ import { trackEvent } from "../util/telemetry"
 export interface ISiteMetadata {
   sitePath: string
   name?: string
+  gatsbyVersion?: string
   lastRun?: number
   pid?: number
   hash?: string
@@ -98,7 +99,7 @@ const STOPPED_STATES = [GlobalStatus.NotStarted, GlobalStatus.Failed, `STOPPED`]
 export class GatsbySite {
   siteStatus: ISiteStatus = DEFAULT_STATUS
   startedInDesktop?: boolean
-
+  gatsbyVersion?: string
   private _listeners = new Set<(status: ISiteStatus, action?: Action) => void>()
 
   constructor(

--- a/src/pages/sites/[hash].tsx
+++ b/src/pages/sites/[hash].tsx
@@ -6,6 +6,8 @@ import { Layout } from "../../components/layout"
 import { SiteActions } from "../../components/site-actions"
 import { GatsbySite } from "../../controllers/site"
 import { GlobalStatus } from "../../util/ipc-types"
+import { supportsAdmin } from "../../util/site-status"
+import { useMemo } from "react"
 
 export interface IProps {
   params: {
@@ -27,6 +29,30 @@ export default function SitePage({ params }: IProps): JSX.Element {
 
 function SiteDetails({ site }: { site: GatsbySite }): JSX.Element {
   const { running, port, status } = useSiteRunnerStatus(site)
+
+  const version = site.gatsbyVersion
+
+  const adminSupported = useMemo(() => version && supportsAdmin(version), [
+    version,
+  ])
+
+  if (!adminSupported) {
+    return (
+      <Flex
+        sx={{
+          alignItems: `center`,
+          justifyContent: `center`,
+          width: `100%`,
+          height: `100%`,
+        }}
+      >
+        <EmptyState
+          heading="Please upgrade Gatsby"
+          text={`Your site's version of Gatsby does not support Gatsby Admin. Please upgrade to the latest version`}
+        />
+      </Flex>
+    )
+  }
 
   return (
     <Flex sx={{ height: `100%` }}>

--- a/src/util/site-runners.tsx
+++ b/src/util/site-runners.tsx
@@ -86,6 +86,7 @@ export function RunnerProvider({
             console.log(`loading existing site service config`)
             existingSite.name = site.name || existingSite.name
             existingSite.startedInDesktop = status?.startedInDesktop
+            existingSite.gatsbyVersion = site.gatsbyVersion
             existingSite.updateStatus({
               pid: site.pid,
             })
@@ -94,6 +95,7 @@ export function RunnerProvider({
           }
           console.log(`loading new site`, site)
           const newSite = new GatsbySite(site.sitePath, site.name)
+          newSite.gatsbyVersion = site.gatsbyVersion
           if (status) {
             newSite.updateStatus(status)
             newSite.startedInDesktop = status?.startedInDesktop

--- a/src/util/site-status.ts
+++ b/src/util/site-status.ts
@@ -1,6 +1,6 @@
 import { Status, WorkerStatus } from "../controllers/site"
 import { GlobalStatus } from "./ipc-types"
-
+import satisfies from "semver/functions/satisfies"
 /* eslint-disable @typescript-eslint/naming-convention */
 export enum SiteDisplayStatus {
   Stopped = `STOPPED`,
@@ -8,6 +8,9 @@ export enum SiteDisplayStatus {
   Running = `RUNNING`,
   Errored = `ERRORED`,
 }
+
+export const MIN_ADMIN_VERSION = `>=2.24.17`
+
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export function getSiteDisplayStatus(status: Status): SiteDisplayStatus {
@@ -45,4 +48,8 @@ export function isRunning(status: Status): boolean {
 
 export function isStarting(status: Status): boolean {
   return status === GlobalStatus.InProgress
+}
+
+export function supportsAdmin(version: string): boolean {
+  return satisfies(version, MIN_ADMIN_VERSION, { includePrerelease: true })
 }


### PR DESCRIPTION
We need to check if a site supports admin, otherwise we'll display a 404 page. This PR checks the site's installed version of gatsby, and displays a warning instead if the version is too old. 

Currently this has a false negative on monorepos where gatsby has been hoisted to the top level, because currently we only look in `<baseDir>/node_modules/gatsby`. This is because of an Electron bug, where `require.resolve` does not respect the `paths` option. We can fix this if electron/electron#25891 is merged and released